### PR TITLE
Set default language instead of an empty one

### DIFF
--- a/client/src/components/admin/EditSurveySectionTranslations.tsx
+++ b/client/src/components/admin/EditSurveySectionTranslations.tsx
@@ -213,7 +213,7 @@ export default function EditSurveySectionTranslations({
       {section.type === 'text' && (
         <RichTextEditor
           value={section.body?.[languageCode]}
-          missingValue={Boolean(section.body?.[languageCode])}
+          missingValue={Boolean(!section.body?.[languageCode])}
           onChange={(value) => {
             onEdit({
               ...section,

--- a/client/src/stores/TranslationContext.tsx
+++ b/client/src/stores/TranslationContext.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useContext, useMemo, useReducer } from 'react';
-import fi from './fi.json';
-import en from './en.json';
 import { useHistory } from 'react-router-dom';
+import en from './en.json';
+import fi from './fi.json';
 
 // Object containing all translations
 const translations = {
@@ -65,8 +65,11 @@ export function useTranslations() {
   const [state, dispatch] = context;
 
   const setLanguage = (language: Language) => {
-    history.push(`?lang=${language}`);
-    dispatch({ type: 'SET_LANGUAGE', language });
+    history.push(`?lang=${language ?? stateDefaults.surveyLanguage}`);
+    dispatch({
+      type: 'SET_LANGUAGE',
+      language: language ?? stateDefaults.surveyLanguage,
+    });
   };
 
   const setSurveyLanguage = (language: Language) => {

--- a/server/src/email/unfinished-submission.ts
+++ b/server/src/email/unfinished-submission.ts
@@ -19,7 +19,9 @@ export async function sendUnfinishedSubmissionLink({
 }) {
   const tr = useTranslations(language);
   const subject = `${survey.title[language]} - ${tr.unfinishedSubmission}`;
-  const url = `${process.env.EMAIL_APP_URL}/${survey.name}?token=${token}`;
+  const url = `${process.env.EMAIL_APP_URL}/${survey.name}?token=${token}${
+    language ? `?lang=${language}` : ''
+  }`;
   try {
     await sendMail({
       message: {


### PR DESCRIPTION
- Fixed a problem with unfinished submissions trying to assign an empty/undefined language
- `setLanguage` will now fallback to the default language if a nullish language was given