### PR TITLE
Modify function which handles copying translation rows to clipboard

### DIFF
--- a/client/src/components/admin/EditSurveyTranslations.tsx
+++ b/client/src/components/admin/EditSurveyTranslations.tsx
@@ -68,17 +68,18 @@ function surveyToTranslationString(survey: Survey): string {
   ): string {
     return `${label} \t ${valueFi} \t ${valueEn} \n`;
   }
-  // Uses recursion to loop through the entire Survey object and to add all values of objects of type LocalizedText
-  function addRowString(obj: any, label: string) {
+  // Uses recursion to loop through the entire Survey object and to add all values of objects of type LocalizedText to the clipboard
+  function addRowString(obj: any, label: string, index: number = 0) {
     Object.keys(obj).forEach((key: string) => {
       if (!obj[key]) {
         return;
       } else if (Array.isArray(obj[key])) {
+        index = 1;
         obj[key].forEach((array: [any]) =>
-          addRowString(array, `${label}.${key}`)
+          addRowString(array, `${label}.${key}[${index}]`, index++)
         );
       } else if (typeof obj[key] === 'object' && !isLocalizedText(obj[key])) {
-        addRowString(obj[key], `${label}.${key}`);
+        addRowString(obj[key], `${label}.${key}[${index}]`, index);
       } else if (isLocalizedText(obj[key])) {
         surveyStrings.push(
           getRowString(`${label}.${key}`, obj[key].fi, obj[key].en)

--- a/client/src/components/admin/EditSurveyTranslations.tsx
+++ b/client/src/components/admin/EditSurveyTranslations.tsx
@@ -66,9 +66,6 @@ function surveyToTranslationString(survey: Survey): string {
     valueFi: string,
     valueEn: string
   ): string {
-    if (label == '' || valueFi == '' || valueEn == '') {
-      return '';
-    }
     return `${label} \t ${valueFi} \t ${valueEn} \n`;
   }
   // Uses recursion to loop through the entire Survey object and to add all values of objects of type LocalizedText

--- a/client/src/components/admin/EditSurveyTranslations.tsx
+++ b/client/src/components/admin/EditSurveyTranslations.tsx
@@ -52,7 +52,7 @@ function surveyToTranslationString(survey: Survey) {
   const columnHeaders = 'Label \t fi \t en \n';
   const surveyStrings: string[] = [];
 
-  function isLocalizedText(value: any): boolean {
+  function isLocalizedText(value: unknown): value is LocalizedText {
     return (
       typeof value === 'object' &&
       value !== null &&

--- a/client/src/components/admin/EditSurveyTranslations.tsx
+++ b/client/src/components/admin/EditSurveyTranslations.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles({
   },
 });
 
-function surveyToTranslationString(survey: Survey): string {
+function surveyToTranslationString(survey: Survey) {
   const columnHeaders = 'Label \t fi \t en \n';
   const surveyStrings: string[] = [];
 

--- a/client/src/components/admin/EditSurveyTranslations.tsx
+++ b/client/src/components/admin/EditSurveyTranslations.tsx
@@ -1,11 +1,4 @@
-import {
-  //LocalizedText,
-  //SectionOption,
-  //SectionOptionGroup,
-  Survey,
-  SurveyEmailInfoItem,
-  //SurveyPageSection,
-} from '@interfaces/survey';
+import { Survey, SurveyEmailInfoItem } from '@interfaces/survey';
 import {
   Checkbox,
   FormControlLabel,


### PR DESCRIPTION
When "copy to clipboard" button is pressed a string is copied which can be pasted directly to a spreadsheet.
The resulting table has three columns "Label", "fi" and "en". The "Label" column  shows the survey context
and "fi" and "en" show label values in respective languages.

Closes #109 