### PR TITLE
Feature/thanks page picture

### DIFF
--- a/client/src/components/SurveyThanksPage.tsx
+++ b/client/src/components/SurveyThanksPage.tsx
@@ -2,7 +2,7 @@ import { Survey } from '@interfaces/survey';
 import { Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { useTranslations } from '@src/stores/TranslationContext';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeExternalLinks from 'rehype-external-links';
 import TreBanner from './logos/TreBanner';
@@ -34,6 +34,27 @@ interface Props {
 }
 
 export default function SurveyThanksPage({ survey, isTestSurvey }: Props) {
+  const [image, setImage] = useState<{
+    url: string;
+    alt: string;
+  } | null>(null);
+
+  useEffect(() => {
+    async function getThanksPageImage() {
+      const res = await fetch(
+        `api/file/${survey.thanksPage.imagePath[0]}/${survey.thanksPage.imageName}`
+      );
+      const blob = await res.blob();
+
+      const altText: string = JSON.parse(
+        res.headers.get('File-details')
+      ).imageAltText;
+
+      setImage({ url: URL.createObjectURL(blob), alt: altText });
+    }
+    getThanksPageImage();
+  }, []);
+
   const classes = useStyles();
   const { tr, surveyLanguage } = useTranslations();
 
@@ -61,6 +82,10 @@ export default function SurveyThanksPage({ survey, isTestSurvey }: Props) {
         <ReactMarkdown rehypePlugins={[rehypeExternalLinks]}>
           {survey.thanksPage.text?.[surveyLanguage]}
         </ReactMarkdown>
+        {image && (
+          <img style={{ maxHeight: '800px' }} src={image.url} alt={image.alt} />
+        )}
+
         <div
           style={{
             position: 'absolute',

--- a/client/src/components/SurveyThanksPage.tsx
+++ b/client/src/components/SurveyThanksPage.tsx
@@ -34,27 +34,24 @@ interface Props {
 }
 
 export default function SurveyThanksPage({ survey, isTestSurvey }: Props) {
-  const [image, setImage] = useState<{
-    url: string;
-    alt: string;
-  } | null>(null);
+  const [imageAltText, setImageAltText] = useState<string | null>(null);
 
   useEffect(() => {
-    async function getThanksPageImage() {
+    async function getImageHeaders() {
       const res = await fetch(
-        `api/file/${survey.thanksPage.imagePath[0]}/${survey.thanksPage.imageName}`
+        `api/file/${survey.thanksPage.imagePath[0]}/${survey.thanksPage.imageName}`,
+        { method: 'HEAD' }
       );
-      const blob = await res.blob();
 
       const altText: string = JSON.parse(
         res.headers.get('File-details')
       ).imageAltText;
 
-      setImage({ url: URL.createObjectURL(blob), alt: altText });
+      setImageAltText(altText);
     }
     survey.thanksPage.imagePath.length > 0 &&
       survey.thanksPage.imageName &&
-      getThanksPageImage();
+      getImageHeaders();
   }, []);
 
   const classes = useStyles();
@@ -84,8 +81,12 @@ export default function SurveyThanksPage({ survey, isTestSurvey }: Props) {
         <ReactMarkdown rehypePlugins={[rehypeExternalLinks]}>
           {survey.thanksPage.text?.[surveyLanguage]}
         </ReactMarkdown>
-        {image && (
-          <img style={{ maxHeight: '800px' }} src={image.url} alt={image.alt} />
+        {imageAltText && (
+          <img
+            style={{ maxHeight: '800px' }}
+            src={`api/file/${survey.thanksPage.imagePath[0]}/${survey.thanksPage.imageName}`}
+            alt={imageAltText}
+          />
         )}
 
         <div

--- a/client/src/components/SurveyThanksPage.tsx
+++ b/client/src/components/SurveyThanksPage.tsx
@@ -52,7 +52,9 @@ export default function SurveyThanksPage({ survey, isTestSurvey }: Props) {
 
       setImage({ url: URL.createObjectURL(blob), alt: altText });
     }
-    getThanksPageImage();
+    survey.thanksPage.imagePath.length > 0 &&
+      survey.thanksPage.imageName &&
+      getThanksPageImage();
   }, []);
 
   const classes = useStyles();

--- a/client/src/components/admin/EditSurveyInfo.tsx
+++ b/client/src/components/admin/EditSurveyInfo.tsx
@@ -200,7 +200,7 @@ export default function EditSurveyInfo() {
             </ul>
           </div>
         )}
-        <SurveyImageList />
+        <SurveyImageList imageType={'backgroundImage'} />
         <ThemeSelect
           value={activeSurvey.theme?.id}
           onChange={(theme) => {

--- a/client/src/components/admin/EditSurveyThanksPage.tsx
+++ b/client/src/components/admin/EditSurveyThanksPage.tsx
@@ -4,10 +4,12 @@ import Fieldset from '../Fieldset';
 import { TextField } from '@mui/material';
 import { useTranslations } from '@src/stores/TranslationContext';
 import RichTextEditor from '../RichTextEditor';
+import SurveyImageList from './SurveyImageList';
 
 export default function EditSurveyThanksPage() {
   const { activeSurvey, activeSurveyLoading, editSurvey } = useSurvey();
   const { tr, surveyLanguage } = useTranslations();
+
   return (
     <Fieldset loading={activeSurveyLoading}>
       <TextField
@@ -42,6 +44,7 @@ export default function EditSurveyThanksPage() {
           });
         }}
       />
+      <SurveyImageList imageType={'thanksPageImage'} />
     </Fieldset>
   );
 }

--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -4,6 +4,7 @@ import { File, ImageType } from '@interfaces/survey';
 import {
   Box,
   Button,
+  Container,
   Dialog,
   DialogActions,
   DialogContent,
@@ -299,20 +300,28 @@ export default function SurveyImageList({ imageType }: Props) {
               }
               onClick={() => handleEmptyImage()}
             >
-              <span
+              <Container
                 style={{
-                  marginTop: '70px',
                   display: 'flex',
-                  textAlign: 'center',
+                  padding: '0px 4px',
+                  height: '100%',
+                  maxWidth: '155px',
+                  flexDirection: 'column',
                   justifyContent: 'center',
                 }}
               >
-                {imageType === 'backgroundImage'
-                  ? tr.SurveyImageList.noBackgroundImage
-                  : imageType === 'thanksPageImage'
-                  ? tr.SurveyImageList.noThanksPageImage
-                  : tr.SurveyImageList.noImage}
-              </span>
+                <Typography
+                  style={{
+                    textAlign: 'center',
+                  }}
+                >
+                  {imageType === 'backgroundImage'
+                    ? tr.SurveyImageList.noBackgroundImage
+                    : imageType === 'thanksPageImage'
+                    ? tr.SurveyImageList.noThanksPageImage
+                    : tr.SurveyImageList.noImage}
+                </Typography>
+              </Container>
             </ImageListItem>
             {images.map((image) => (
               <ImageListItem

--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -189,25 +189,25 @@ export default function SurveyImageList({ imageType }: Props) {
   }
 
   function getActiveImage() {
-    const activeImage;
     switch (imageType) {
       case 'backgroundImage':
-        activeImage =
+        return (
           images?.find(
             (image) =>
               image.fileName === activeSurvey.backgroundImageName &&
               image.filePath.join() === activeSurvey.backgroundImagePath.join()
-          ) ?? null;
+          ) ?? null
+        );
         break;
       case 'thanksPageImage':
-        activeImage =
+        return (
           images?.find(
             (image) =>
               image.fileName === activeSurvey.thanksPage.imageName &&
               image.filePath.join() === activeSurvey.thanksPage.imagePath.join()
-          ) ?? null;
+          ) ?? null
+        );
     }
-    return activeImage;
   }
 
   function getImageBorderStyle(image: File) {

--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -198,7 +198,6 @@ export default function SurveyImageList({ imageType }: Props) {
               image.filePath.join() === activeSurvey.backgroundImagePath.join()
           ) ?? null
         );
-        break;
       case 'thanksPageImage':
         return (
           images?.find(

--- a/client/src/components/admin/SurveyImageList.tsx
+++ b/client/src/components/admin/SurveyImageList.tsx
@@ -1,7 +1,8 @@
 // @ts-nocheck
 
-import { File } from '@interfaces/survey';
+import { File, ImageType } from '@interfaces/survey';
 import {
+  Box,
   Button,
   Dialog,
   DialogActions,
@@ -50,7 +51,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export default function SurveyImageList() {
+interface Props {
+  imageType: ImageType;
+}
+
+export default function SurveyImageList({ imageType }: Props) {
   const classes = useStyles();
   const { tr } = useTranslations();
   const { editSurvey, activeSurvey } = useSurvey();
@@ -58,14 +63,29 @@ export default function SurveyImageList() {
   const [images, setImages] = useState<File[]>([]);
   const [imageDialogOpen, setImageDialogOpen] = useState(false);
   const [imageAttributions, setImageAttributions] = useState<string>('');
+  const [imageAltText, setImageAltText] = useState<string | null>(null);
+  const [activeImage, setActiveImage] = useState<File | null>(null);
 
   /** Fetch all images from db during component mount */
   useEffect(() => {
     getImages();
   }, []);
 
+  useEffect(() => {
+    setActiveImage(getActiveImage());
+  });
+
   async function getImages() {
-    const res = await request<File[]>(`/api/file/`);
+    const res = await request<File[]>(
+      `/api/file/${
+        imageType === 'backgroundImage'
+          ? 'background-images'
+          : imageType === 'thanksPageImage'
+          ? 'thanks-page-images'
+          : ''
+      }`
+    );
+
     setImages(res);
   }
 
@@ -75,11 +95,24 @@ export default function SurveyImageList() {
     if (!fileName) {
       return;
     }
-    editSurvey({
-      ...activeSurvey,
-      backgroundImageName: fileName,
-      backgroundImagePath: filePath,
-    });
+    switch (imageType) {
+      case 'backgroundImage':
+        editSurvey({
+          ...activeSurvey,
+          backgroundImageName: fileName,
+          backgroundImagePath: filePath,
+        });
+        break;
+      case 'thanksPageImage':
+        editSurvey({
+          ...activeSurvey,
+          thanksPage: {
+            ...activeSurvey.thanksPage,
+            imageName: fileName,
+            imagePath: filePath,
+          },
+        });
+    }
   }
 
   async function handleDeletingImage(
@@ -116,26 +149,80 @@ export default function SurveyImageList() {
     const formData = new FormData();
     formData.append('file', acceptedFiles[0]);
     formData.append('attributions', imageAttributions);
-    await fetch(`/api/file`, { method: 'POST', body: formData });
+    formData.append('imageAltText', imageAltText);
+
+    await fetch(
+      `/api/file/${
+        imageType === 'backgroundImage'
+          ? 'background-images'
+          : imageType === 'thanksPageImage'
+          ? 'thanks-page-images'
+          : ''
+      }`,
+      { method: 'POST', body: formData }
+    );
     acceptedFiles.shift();
     getImages();
   }
 
   function handleEmptyImage() {
     setImageDialogOpen((prev) => !prev);
-    editSurvey({
-      ...activeSurvey,
-      backgroundImageName: null,
-      backgroundImagePath: [],
-    });
+    switch (imageType) {
+      case 'backgroundImage':
+        editSurvey({
+          ...activeSurvey,
+          backgroundImageName: null,
+          backgroundImagePath: [],
+        });
+        break;
+      case 'thanksPageImage':
+        editSurvey({
+          ...activeSurvey,
+          thanksPage: {
+            ...activeSurvey.thanksPage,
+            imageName: null,
+            imagePath: [],
+          },
+        });
+    }
   }
 
-  const activeImage =
-    images?.find(
-      (image) =>
-        image.fileName === activeSurvey.backgroundImageName &&
-        image.filePath.join() === activeSurvey.backgroundImagePath.join()
-    ) ?? null;
+  function getActiveImage() {
+    const activeImage;
+    switch (imageType) {
+      case 'backgroundImage':
+        activeImage =
+          images?.find(
+            (image) =>
+              image.fileName === activeSurvey.backgroundImageName &&
+              image.filePath.join() === activeSurvey.backgroundImagePath.join()
+          ) ?? null;
+        break;
+      case 'thanksPageImage':
+        activeImage =
+          images?.find(
+            (image) =>
+              image.fileName === activeSurvey.thanksPage.imageName &&
+              image.filePath.join() === activeSurvey.thanksPage.imagePath.join()
+          ) ?? null;
+    }
+    return activeImage;
+  }
+
+  function getImageBorderStyle(image: File) {
+    let style: { border: string } | {} = {};
+    switch (imageType) {
+      case 'backgroundImage':
+        image?.fileName === activeSurvey?.backgroundImageName &&
+          (style = { border: '4px solid #1976d2' });
+        break;
+
+      case 'thanksPageImage':
+        image?.fileName === activeSurvey?.thanksPage.imageName &&
+          (style = { border: '4px solid #1976d2' });
+    }
+    return style;
+  }
 
   return (
     <div>
@@ -154,7 +241,11 @@ export default function SurveyImageList() {
             paddingRight: '0.5rem',
           }}
         >
-          {tr.SurveyImageList.surveyImage.toUpperCase()}
+          {imageType === 'backgroundImage'
+            ? tr.SurveyImageList.surveyImage
+            : imageType === 'thanksPageImage'
+            ? tr.SurveyImageList.thanksPageImage
+            : tr.SurveyImageList.image}
           {': '}
           {activeImage
             ? ` ${activeImage?.fileName}`
@@ -192,8 +283,18 @@ export default function SurveyImageList() {
             <ImageListItem
               className={classes.noImageBackground}
               style={
-                !activeSurvey?.backgroundImageName
-                  ? { border: '4px solid #1976d2' }
+                imageType === 'backgroundImage'
+                  ? !activeSurvey?.backgroundImageName
+                    ? {
+                        border: '4px solid #1976d2',
+                      }
+                    : null
+                  : imageType === 'thanksPageImage'
+                  ? !activeSurvey?.thanksPage.imageName
+                    ? {
+                        border: '4px solid #1976d2',
+                      }
+                    : null
                   : null
               }
               onClick={() => handleEmptyImage()}
@@ -201,19 +302,21 @@ export default function SurveyImageList() {
               <span
                 style={{
                   marginTop: '70px',
-                  alignSelf: 'center',
+                  display: 'flex',
+                  textAlign: 'center',
+                  justifyContent: 'center',
                 }}
               >
-                {tr.SurveyImageList.noImage}
+                {imageType === 'backgroundImage'
+                  ? tr.SurveyImageList.noBackgroundImage
+                  : imageType === 'thanksPageImage'
+                  ? tr.SurveyImageList.noThanksPageImage
+                  : tr.SurveyImageList.noImage}
               </span>
             </ImageListItem>
             {images.map((image) => (
               <ImageListItem
-                style={
-                  image.fileName === activeSurvey?.backgroundImageName
-                    ? { border: '4px solid #1976d2' }
-                    : null
-                }
+                style={getImageBorderStyle(image)}
                 key={image.fileName}
                 onClick={() =>
                   handleListItemClick(image.fileName, image.filePath)
@@ -229,7 +332,11 @@ export default function SurveyImageList() {
                 <img
                   src={`data:image/;base64,${image.data}`}
                   srcSet={`data:image/;base64,${image.data}`}
-                  alt={`survey-image-${image.fileName}`}
+                  alt={
+                    imageAltText
+                      ? imageAltText
+                      : `survey-image-${image.fileName}`
+                  }
                   loading="lazy"
                   style={{ height: '100%' }}
                 />
@@ -248,6 +355,14 @@ export default function SurveyImageList() {
             <aside>
               <h4>{tr.SurveyImageList.files}</h4>
               {files}
+
+              <TextField
+                id="outlined-alt-text"
+                label={tr.EditImageSection.altText}
+                value={imageAltText ? imageAltText : ''}
+                onChange={(event) => setImageAltText(event.target.value)}
+                sx={{ marginTop: 1, marginBottom: 1, width: 250 }}
+              />
               <TextField
                 id="outlined-name"
                 label={tr.SurveyImageList.attributions}

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -172,8 +172,12 @@
   },
   "SurveyImageList": {
     "attributions": "Tekijänoikeustiedot",
-    "noImage": "Ei taustakuvaa",
+    "noBackgroundImage": "Ei taustakuvaa",
+    "noThanksPageImage": "Ei Kiitos-sivun kuvaa",
+    "noImage": "Ei kuvaa",
     "surveyImage": "Kyselyn taustakuva",
+    "thanksPageImage": "Kiitos-sivun kuva",
+    "image": "Kuva",
     "selectImage": "Valitse taustakuva",
     "addNewImage": "Lisää uusi kuva",
     "files": "Tiedosto"

--- a/interfaces/survey.d.ts
+++ b/interfaces/survey.d.ts
@@ -367,6 +367,14 @@ export interface Survey {
      * Text in markdown format
      */
     text: LocalizedText;
+    /**
+     * Name of the thanks page image
+     */
+    imageName?: string;
+    /**
+     * Path of the thanks page image
+     */
+    imagePath?: string[];
   };
   /**
    * Theme of the survey
@@ -577,13 +585,17 @@ export interface File {
 }
 
 /**
- * Image used as the background of the survey landing page
+ * Image used as the background of the survey landing page or in the thank you page
  */
-export interface SurveyBackgroundImage extends File {
+export interface SurveyImage extends File {
   /**
    * Image attributions (= who owns the image rights)
    */
   attributions: string;
+  /**
+   * Alternative text for the picture entered by the user
+   */
+  altText: string;
 }
 
 /**
@@ -638,3 +650,5 @@ export interface SurveyEmailInfoItem {
   name: LocalizedText;
   value: LocalizedText;
 }
+
+export type ImageType = 'backgroundImage' | 'thanksPageImage';

--- a/server/migrations/1687767750027_thankspage-image.ts
+++ b/server/migrations/1687767750027_thankspage-image.ts
@@ -1,0 +1,13 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`ALTER TABLE data.survey ADD COLUMN thanks_page_image_name TEXT;
+  ALTER TABLE data.survey ADD COLUMN thanks_page_image_path TEXT[] DEFAULT ARRAY[]::TEXT[];`);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`ALTER TABLE data.survey DROP COLUMN thanks_page_image_name;
+  ALTER TABLE data.survey DROP COLUMN thanks_page_image_path;`);
+}

--- a/server/src/routes/file.routes.ts
+++ b/server/src/routes/file.routes.ts
@@ -5,7 +5,7 @@ import {
   storeFile,
 } from '@src/application/survey';
 import { ensureAuthenticated } from '@src/auth';
-import { validateRequest } from '@src/utils';
+import { parseImageType, validateRequest } from '@src/utils';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { param } from 'express-validator';
@@ -47,6 +47,21 @@ router.post(
 );
 
 /**
+ * Endpoint for fetching all available survey images with certain type specified by filepath
+ */
+router.get(
+  '/:filePath?',
+  ensureAuthenticated(),
+  asyncHandler(async (req, res) => {
+    const { filePath } = req.params;
+    const filePathArray = filePath?.split('/') ?? [];
+    const row = await getImages(filePathArray);
+
+    res.status(200).json(row);
+  })
+);
+
+/**
  * Endpoint for fetching a single local file
  */
 router.get(
@@ -65,18 +80,6 @@ router.get(
     res.set('Content-type', row.mimeType);
     res.set('File-details', JSON.stringify(row.details));
     res.status(200).send(row.data);
-  })
-);
-
-/**
- * Endpoint for fetching all available survey background images
- */
-router.get(
-  '/',
-  ensureAuthenticated(),
-  asyncHandler(async (req, res) => {
-    const row = await getImages();
-    res.status(200).json(row);
   })
 );
 

--- a/server/src/routes/survey.routes.ts
+++ b/server/src/routes/survey.routes.ts
@@ -123,7 +123,15 @@ router.put(
     body('backgroundImagePath')
       .isArray()
       .optional({ nullable: true })
-      .withMessage('Background image path must be a string'),
+      .withMessage('Background image path must be an array'),
+    body('thanksPageImageName')
+      .isString()
+      .optional({ nullable: true })
+      .withMessage('Thanks page image name must be a string'),
+    body('thanksPageImagePath')
+      .isArray()
+      .optional({ nullable: true })
+      .withMessage('Thanks page image path must be an array'),
     body('startDate')
       .isString()
       .optional({ nullable: true })

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { ValidationChain, validationResult } from 'express-validator';
 import { BadRequestError } from './error';
+import { ImageType } from '@interfaces/survey';
 
 /**
  * Middleware function for validating a request against provided validation rules.
@@ -36,4 +37,19 @@ export function base64Encode(str: string) {
  */
 export function base64Decode(str: string) {
   return Buffer.from(str, 'base64').toString('ascii');
+}
+
+function isString(text: unknown): text is string {
+  return typeof text === 'string' || text instanceof String;
+}
+
+function isImageType(val: string): val is ImageType {
+  return val === 'backgroundImage' || val === 'thanksPageImage';
+}
+
+export function parseImageType(val: unknown): ImageType | null {
+  if (!isString(val) || !isImageType(val)) {
+    throw new Error('Invalid value for imagetype');
+  }
+  return val;
 }


### PR DESCRIPTION
Add possibility to include a user defined image to thank you page. Uses SurveyImageList component which is also used for background image. 

The backend offers an api endpoint with format api/file/<image_type>/<file_name>. All available images of certain type can be fetched using api/file/<image_type>.

Thank you page images are saved to the database to table data.files. Filepath column in the database is used to define the type of the image (background-images or thanks-page-images). 

Closes #105 