### PR TITLE
Add SR announcements to indicate stepper progress

### DIFF
--- a/client/src/components/SurveyStepper.tsx
+++ b/client/src/components/SurveyStepper.tsx
@@ -244,9 +244,10 @@ export default function SurveyStepper({
    * Scroll to page header (=StepLabel) when page changes
    */
   useEffect(() => {
-    const element = document.getElementById(`${pageNumber}-page-top`);
-    if (!element) return;
-    element.scrollIntoView();
+    const heading = document.getElementById(`${pageNumber}-page-heading`);
+    if (!heading) return;
+    heading.scrollIntoView();
+    heading.focus();
   }, [pageNumber]);
 
   /**
@@ -326,14 +327,19 @@ export default function SurveyStepper({
                   iconContainer: classes.stepIcon,
                 }}
               >
-                <h2 style={{ margin: 0, fontSize: '1em' }}>
+                <Typography
+                  id={`${index}-page-heading`}
+                  component="h2"
+                  tabIndex={-1}
+                  sx={{ margin: 0, fontSize: '1em', "&:focus": { outline: 'none'} }}
+                >
                   <span style={visuallyHidden}>
                     {index < pageNumber && tr.SurveyStepper.completedStep}
                     {index > pageNumber && tr.SurveyStepper.futureStep}
                     {tr.SurveyStepper.step} {index + 1} {tr.SurveyStepper.outOf} {survey?.pages?.length}
                   </span>
                   {page.title?.[language]}
-                </h2>
+                </Typography>
               </StepLabel>
 
               <StepContent

--- a/client/src/components/SurveyStepper.tsx
+++ b/client/src/components/SurveyStepper.tsx
@@ -317,7 +317,7 @@ export default function SurveyStepper({
           connector={null}
         >
           {survey.pages.map((page, index) => (
-            <Step key={page.id} completed={index < pageNumber ? true : false}>
+            <Step key={page.id} completed={index < pageNumber}>
               <StepLabel
                 id={`${index}-page-top`}
                 aria-current={index === pageNumber ? "step" : false}

--- a/client/src/components/SurveyStepper.tsx
+++ b/client/src/components/SurveyStepper.tsx
@@ -316,9 +316,10 @@ export default function SurveyStepper({
           connector={null}
         >
           {survey.pages.map((page, index) => (
-            <Step key={page.id} completed={false}>
+            <Step key={page.id} completed={index < pageNumber ? true : false}>
               <StepLabel
                 id={`${index}-page-top`}
+                aria-current={index === pageNumber ? "step" : false}
                 classes={{
                   active: classes.stepActive,
                   label: classes.stepHeader,
@@ -326,6 +327,11 @@ export default function SurveyStepper({
                 }}
               >
                 <h2 style={{ margin: 0, fontSize: '1em' }}>
+                  <span style={visuallyHidden}>
+                    {index < pageNumber && tr.SurveyStepper.completedStep}
+                    {index > pageNumber && tr.SurveyStepper.futureStep}
+                    {tr.SurveyStepper.step} {index + 1} {tr.SurveyStepper.outOf} {survey?.pages?.length}
+                  </span>
                   {page.title?.[language]}
                 </h2>
               </StepLabel>

--- a/client/src/stores/en.json
+++ b/client/src/stores/en.json
@@ -329,7 +329,11 @@
     "openImage": "Open the image",
     "unfinishedAnswers": "Please, answer all mandatory questions.",
     "unfinishedAnswersInfo": "The following answers need to be answered:",
-    "saveAsUnfinished": "Save unfinished survey"
+    "saveAsUnfinished": "Save unfinished survey",
+    "step": "Step",
+    "outOf": "out of",
+    "completedStep": "Completed step",
+    "futureStep": "Future step"
   },
   "SaveAsUnfinishedDialog": {
     "description": "You can save the unfinished survey by providing your email address. A link will be sent to your email, from which you can access your unfinished survey provided that the survey is still open.",

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -329,7 +329,11 @@
     "openImage": "Avaa kuva",
     "unfinishedAnswers": "Vastaa kaikkiin pakolliseksi merkittyihin kysymyksiin.",
     "unfinishedAnswersInfo": "Seuraavat kysymykset ovat vastaamatta:",
-    "saveAsUnfinished": "Tallenna keskeneräisenä"
+    "saveAsUnfinished": "Tallenna keskeneräisenä",
+    "step": "Vaihe",
+    "outOf": "/",
+    "completedStep": "Täytetty vaihe",
+    "futureStep": "Tuleva vaihe"
   },
   "SaveAsUnfinishedDialog": {
     "description": "Voit tallentaa kyselyn keskeneräisenä antamalla sähköpostiosoitteesi. Sähköpostiisi toimitetaan linkki, josta pääset jatkamaan vastaamista kyselyn ollessa auki.",


### PR DESCRIPTION
Screen readers are now able to announce user progress on the page stepper. Browsing headings will announce their position in the sequence, current step is properly indicated and focus is automatically placed on the current page heading.
Also completed steps are now so marked where appropriate as allowed by page sequence having been previously linearized.
Closes #89 