### PR TITLE
Re-implement the language menu accessibly

### DIFF
--- a/client/src/components/LanguageMenu.tsx
+++ b/client/src/components/LanguageMenu.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
-import { IconButton, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
+import { MenuItem, Select, Tooltip } from '@mui/material';
 import { useTranslations } from '@src/stores/TranslationContext';
 import { LanguageCode } from '@interfaces/survey';
 import { makeStyles } from '@mui/styles';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import LanguageIcon from '@mui/icons-material/Language';
+import React from 'react';
 
 interface Props {
   style?: React.CSSProperties;
@@ -11,64 +11,61 @@ interface Props {
 
 const useStyles = makeStyles({
   root: {
+    cursor: 'pointer',
     display: 'flex',
     flexGrow: 1,
     justifyContent: 'flex-end',
   },
 });
 
-export default function LanguageMenu({ style }: Props) {
-  const { tr, setLanguage, languages, language } = useTranslations();
-  const [anchorEl, setAnchorEl] = useState(null);
+export default function LanguageMenu({
+  style,
+}: Props) {
+  const { tr,  setLanguage, languages, language } =
+    useTranslations();
   const classes = useStyles();
-  const open = Boolean(anchorEl);
-  const handleClick = (event: any) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
 
   return (
     <div className={classes.root} style={style}>
-      <Tooltip title={tr.LanguageMenu.changeLanguage}>
-        <IconButton
-          id="basic-button"
-          aria-controls={open ? 'basic-menu' : undefined}
-          aria-haspopup="true"
-          aria-expanded={open ? 'true' : undefined}
-          onClick={handleClick}
-          color="inherit"
-        >
-          <Typography>{language.toLocaleUpperCase()}</Typography>
-          <ArrowDropDownIcon />
-        </IconButton>
-      </Tooltip>
-      <Menu
-        style={{ display: !anchorEl ? 'none' : '' }}
-        id="basic-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        MenuListProps={{
-          'aria-labelledby': 'basic-button',
-        }}
+      <Tooltip
+        arrow
+        placement='left'
+        title={tr.LanguageMenu.changeLanguage}
       >
-        {languages.map((lang, index) => (
-          <MenuItem
-            key={`lang-item-${index}`}
-            lang={lang}
-            selected={lang === language}
-            onClick={(event) => {
-              handleClose();
-              const target = event.target as HTMLInputElement;
-              setLanguage(target.lang as LanguageCode);
-            }}
-          >
-            {tr.LanguageMenu[lang]} ({lang.toLocaleUpperCase()})
-          </MenuItem>
-        ))}
-      </Menu>
+        <Select
+          inputProps={{"aria-label": tr.LanguageMenu.languageControl}}
+          value={language}
+          onChange={(event) => {
+            const targetLanguage = event.target.value as LanguageCode;
+            setLanguage(targetLanguage);
+          }}
+          IconComponent={LanguageIcon}
+          sx={{
+            color: 'inherit',
+            '&>.MuiSelect-select': { // Accommodate the larger globe icon
+              paddingRight: '38px !important',
+            },
+            '&>fieldset': { // Visual label not used, hide border and legend
+              borderWidth: 0,
+              '&>legend': {display: 'none'},
+            },
+            '& svg': { // The component is used in admin panel and survey, must adapt
+              color: 'inherit',
+              fill: 'currentColor',
+            }
+          }}
+        >
+          {languages.map((lang, index) => (
+            <MenuItem
+              key={`lang-item-${index}`}
+              value={lang}
+              selected={lang === language}
+            >
+              {tr.LanguageMenu[lang]} ({lang.toLocaleUpperCase()})
+            </MenuItem>
+          ))}
+        </Select>
+      </Tooltip>
     </div>
   );
 }

--- a/client/src/components/SurveyLanguageMenu.tsx
+++ b/client/src/components/SurveyLanguageMenu.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, Select } from '@mui/material';
+import { MenuItem, Select, Tooltip } from '@mui/material';
 import { useTranslations } from '@src/stores/TranslationContext';
 import { LanguageCode } from '@interfaces/survey';
 import { makeStyles } from '@mui/styles';
@@ -29,33 +29,46 @@ export default function SurveyLanguageMenu({
 
   return (
     <div className={classes.root} style={style}>
-      <Select
-        inputProps={{"aria-label": tr.SurveyLanguageMenu.languageControl}}
-        value={surveyLanguage}
-        onChange={(event) => {
-          const targetLanguage = event.target.value as LanguageCode;
-          setSurveyLanguage(targetLanguage);
-          if (changeUILanguage) setLanguage(targetLanguage);
-        }}
-        IconComponent={LanguageIcon}
-        sx={{
-          /* Visual label not used, hide the border and legend */
-          '& fieldset': {
-            borderWidth: 0,
-            '&>legend': {display: 'none'}
-          }
-        }}
+      <Tooltip
+        arrow
+        placement='left'
+        title={tr.SurveyLanguageMenu.changeSurveyLanguage}
       >
-        {languages.map((lang, index) => (
-          <MenuItem
-            key={`lang-item-${index}`}
-            value={lang}
-            selected={lang === surveyLanguage}
-          >
-            {tr.LanguageMenu[lang]} ({lang.toLocaleUpperCase()})
-          </MenuItem>
-        ))}
-      </Select>
+        <Select
+          inputProps={{"aria-label": tr.SurveyLanguageMenu.languageControl}}
+          value={surveyLanguage}
+          onChange={(event) => {
+            const targetLanguage = event.target.value as LanguageCode;
+            setSurveyLanguage(targetLanguage);
+            if (changeUILanguage) setLanguage(targetLanguage);
+          }}
+          IconComponent={LanguageIcon}
+          sx={{
+            color: 'inherit',
+            '&>.MuiSelect-select': { // Accommodate the larger globe icon
+              paddingRight: '38px !important',
+            },
+            '&>fieldset': { // Visual label not used, hide border and legend
+              borderWidth: 0,
+              '&>legend': {display: 'none'},
+            },
+            '& svg': { // The component is used in admin panel and survey, must adapt
+              color: 'inherit',
+              fill: 'currentColor',
+            }
+          }}
+        >
+          {languages.map((lang, index) => (
+            <MenuItem
+              key={`lang-item-${index}`}
+              value={lang}
+              selected={lang === surveyLanguage}
+            >
+              {tr.LanguageMenu[lang]} ({lang.toLocaleUpperCase()})
+            </MenuItem>
+          ))}
+        </Select>
+      </Tooltip>
     </div>
   );
 }

--- a/client/src/components/SurveyLanguageMenu.tsx
+++ b/client/src/components/SurveyLanguageMenu.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
-import { Menu, MenuItem, Tooltip, Typography } from '@mui/material';
+import { MenuItem, Select } from '@mui/material';
 import { useTranslations } from '@src/stores/TranslationContext';
 import { LanguageCode } from '@interfaces/survey';
 import { makeStyles } from '@mui/styles';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import LanguageIcon from '@mui/icons-material/Language';
+import React from 'react';
 
 interface Props {
   style?: React.CSSProperties;
@@ -25,65 +25,37 @@ export default function SurveyLanguageMenu({
 }: Props) {
   const { tr, setSurveyLanguage, setLanguage, languages, surveyLanguage } =
     useTranslations();
-  const [anchorEl, setAnchorEl] = useState(null);
   const classes = useStyles();
-  const open = Boolean(anchorEl);
-
-  const handleClick = (event: any) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
 
   return (
     <div className={classes.root} style={style}>
-      <Tooltip
-        id="tooltip-button"
-        title={tr.SurveyLanguageMenu.changeSurveyLanguage}
-      >
-        <div
-          onClick={(event) => handleClick(event)}
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-          }}
-        >
-          <Typography>
-            {tr.SurveyLanguageMenu.surveyLanguage} (
-            {surveyLanguage?.toLocaleUpperCase()})
-          </Typography>
-          <ArrowDropDownIcon />
-        </div>
-      </Tooltip>
-      <Menu
-        style={{ display: !anchorEl ? 'none' : '' }}
-        id="basic-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        MenuListProps={{
-          'aria-labelledby': 'tooltip-button',
+      <Select
+        inputProps={{"aria-label": tr.SurveyLanguageMenu.languageControl}}
+        value={surveyLanguage}
+        onChange={(event) => {
+          const targetLanguage = event.target.value as LanguageCode;
+          setSurveyLanguage(targetLanguage);
+          if (changeUILanguage) setLanguage(targetLanguage);
+        }}
+        IconComponent={LanguageIcon}
+        sx={{
+          /* Visual label not used, hide the border and legend */
+          '& fieldset': {
+            borderWidth: 0,
+            '&>legend': {display: 'none'}
+          }
         }}
       >
         {languages.map((lang, index) => (
           <MenuItem
             key={`lang-item-${index}`}
-            lang={lang}
+            value={lang}
             selected={lang === surveyLanguage}
-            onClick={(event) => {
-              handleClose();
-              const targetLanguage = (event.target as HTMLInputElement)
-                .lang as LanguageCode;
-              setSurveyLanguage(targetLanguage);
-              if (changeUILanguage) setLanguage(targetLanguage);
-            }}
           >
             {tr.LanguageMenu[lang]} ({lang.toLocaleUpperCase()})
           </MenuItem>
         ))}
-      </Menu>
+      </Select>
     </div>
   );
 }

--- a/client/src/stores/en.json
+++ b/client/src/stores/en.json
@@ -425,6 +425,7 @@
     "en": "English"
   },
   "SurveyLanguageMenu": {
+    "languageControl": "Language / Kieli",
     "changeSurveyLanguage": "Change language of the survey",
     "surveyLanguage": "Survey language"
   },

--- a/client/src/stores/en.json
+++ b/client/src/stores/en.json
@@ -420,6 +420,7 @@
     "text": "This is a test survey. Survey answers are not saved nor are any email reports sent."
   },
   "LanguageMenu": {
+    "languageControl": "Language / Kieli",
     "changeLanguage": "Change service language",
     "fi": "Suomi",
     "en": "English"

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -425,6 +425,7 @@
     "en": "English"
   },
   "SurveyLanguageMenu": {
+    "languageControl": "Language / Kieli",
     "changeSurveyLanguage": "Vaihda kyselyn kieltä",
     "surveyLanguage": "Kyselyn kieli"
   },

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -420,6 +420,7 @@
     "text": "Tämä on testikysely. Vastauksia ei tallenneta, eikä niistä lähetetä sähköpostia."
   },
   "LanguageMenu": {
+    "languageControl": "Language / Kieli",
     "changeLanguage": "Vaihda palvelun kieltä",
     "fi": "Suomi",
     "en": "English"


### PR DESCRIPTION
In order to improve keyboard operability as called for in issue #86, the language menu is now implemented with off-the-shelf `<Select>` element.