### PR TITLE
Store map layer selections for answers

### DIFF
--- a/client/src/components/MapQuestion.tsx
+++ b/client/src/components/MapQuestion.tsx
@@ -61,7 +61,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
         valueRef.current.map((answer, index) => ({
           ...answer,
           geometry: features[index],
-        }))
+        })),
       );
     });
     // On unmount unregister the event handler
@@ -116,6 +116,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
           selectionType,
           geometry,
           subQuestionAnswers,
+          mapLayers: [],
         },
       ]);
       setSelectionType(null);
@@ -163,9 +164,9 @@ export default function MapQuestion({ value, onChange, question }: Props) {
           () => (answers: SurveyMapSubQuestionAnswer[]) => {
             resolve(answers);
             setSubQuestionDialogOpen(false);
-          }
+          },
         );
-      }
+      },
     );
   }
 
@@ -263,8 +264,8 @@ export default function MapQuestion({ value, onChange, question }: Props) {
             value.map((answer, index) =>
               index === editingMapAnswer.index
                 ? { ...answer, subQuestionAnswers: answers }
-                : answer
-            )
+                : answer,
+            ),
           );
           stopEditingMapAnswer();
         }}
@@ -293,7 +294,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
         onClose={(result) => {
           if (result) {
             onChange(
-              value.filter((_, index) => index !== editingMapAnswer.index)
+              value.filter((_, index) => index !== editingMapAnswer.index),
             );
             stopEditingMapAnswer();
           }

--- a/client/src/stores/SurveyAnswerContext.tsx
+++ b/client/src/stores/SurveyAnswerContext.tsx
@@ -8,8 +8,8 @@ import {
 } from '@interfaces/survey';
 import { request } from '@src/utils/request';
 import React, {
-  createContext,
   ReactNode,
+  createContext,
   useContext,
   useMemo,
   useReducer,
@@ -26,6 +26,10 @@ type Action =
   | {
       type: 'SET_SURVEY';
       survey: Survey;
+    }
+  | {
+      type: 'UPDATE_SURVEY_PAGE';
+      page: SurveyPage;
     }
   | {
       type: 'UPDATE_ANSWER';
@@ -128,7 +132,7 @@ export function getEmptyAnswer(section: SurveyPageSection): AnswerEntry {
       };
     default:
       throw new Error(
-        `No default value defined for questions of type "${section.type}"`
+        `No default value defined for questions of type "${section.type}"`,
       );
   }
 }
@@ -148,7 +152,7 @@ export function useSurveyAnswers() {
 
   function getValidationErrors(
     question: SurveyQuestion,
-    answers = state.answers
+    answers = state.answers,
   ) {
     const errors: ('answerLimits' | 'required' | 'minValue' | 'maxValue')[] =
       [];
@@ -162,7 +166,7 @@ export function useSurveyAnswers() {
       const nonEmptySelections = value.filter(
         (selection) =>
           selection != null &&
-          (typeof selection !== 'string' || selection.length > 0)
+          (typeof selection !== 'string' || selection.length > 0),
       );
       if (
         // If either limit is defined and that limit is broken, the answer is invalid
@@ -256,7 +260,7 @@ export function useSurveyAnswers() {
         // Skip sections that shouldn't get answers
         .filter(
           (section): section is SurveyQuestion =>
-            !nonQuestionSectionTypes.includes(section.type)
+            !nonQuestionSectionTypes.includes(section.type),
         )
         .some((section) => getValidationErrors(section).length);
     },
@@ -271,7 +275,7 @@ export function useSurveyAnswers() {
           // Skip sections that shouldn't get answers
           .filter(
             (section): section is SurveyQuestion =>
-              !nonQuestionSectionTypes.includes(section.type)
+              !nonQuestionSectionTypes.includes(section.type),
           )
           .map((section) => ({
             [section.title[surveyLanguage]]: getValidationErrors(section),
@@ -288,7 +292,7 @@ export function useSurveyAnswers() {
         answers: AnswerEntry[];
         language: LanguageCode;
       }>(
-        `/api/published-surveys/${state.survey.name}/unfinished-submission?token=${token}`
+        `/api/published-surveys/${state.survey.name}/unfinished-submission?token=${token}`,
       );
       const { answers, language } = response;
       dispatch({
@@ -303,6 +307,17 @@ export function useSurveyAnswers() {
      */
     setUnfinishedToken(token: string) {
       dispatch({ type: 'SET_UNFINISHED_TOKEN', token });
+    },
+    /**
+     * Updates the given map layers to the state.
+     * @param page Page to be updated
+     * @param mapLayers Visible map layers
+     */
+    updatePageMapLayers(page: SurveyPage, mapLayers: number[]) {
+      dispatch({
+        type: 'UPDATE_SURVEY_PAGE',
+        page: { ...page, sidebar: { ...page.sidebar, mapLayers } },
+      });
     },
   };
 }
@@ -320,11 +335,21 @@ function reducer(state: State, action: Action): State {
         ...state,
         survey: action.survey,
       };
+    case 'UPDATE_SURVEY_PAGE':
+      return {
+        ...state,
+        survey: {
+          ...state.survey,
+          pages: state.survey.pages.map((page) =>
+            page.id === action.page.id ? action.page : page,
+          ),
+        },
+      };
     case 'UPDATE_ANSWER':
       return {
         ...state,
         answers: state.answers.map((answer) =>
-          answer.sectionId === action.answer.sectionId ? action.answer : answer
+          answer.sectionId === action.answer.sectionId ? action.answer : answer,
         ),
       };
     case 'UPDATE_ANSWERS':
@@ -333,7 +358,7 @@ function reducer(state: State, action: Action): State {
         answers: state.answers.map(
           (answer) =>
             action.answers.find((a) => a.sectionId === answer.sectionId) ??
-            answer
+            answer,
         ),
       };
     case 'SET_ANSWERS':

--- a/client/src/typings/oskari-rpc.d.ts
+++ b/client/src/typings/oskari-rpc.d.ts
@@ -23,8 +23,8 @@ declare module 'oskari-rpc' {
           showMeasureOnMap?: boolean;
           selfIntersection?: boolean;
           geojson?: GeoJSON.GeoJSON;
-        }
-      ]
+        },
+      ],
     ) => void;
 
     /**
@@ -32,7 +32,7 @@ declare module 'oskari-rpc' {
      */
     export type StopDrawingRequest = (
       name: 'DrawTools.StopDrawingRequest',
-      params: [id: string, clearCurrent?: boolean, supressEvent?: boolean]
+      params: [id: string, clearCurrent?: boolean, supressEvent?: boolean],
     ) => void;
   }
 
@@ -45,7 +45,7 @@ declare module 'oskari-rpc' {
      */
     export type MapLayerVisibilityRequest = (
       name: 'MapModulePlugin.MapLayerVisibilityRequest',
-      params: [layerId: number, visibility: boolean]
+      params: [layerId: number, visibility: boolean],
     ) => void;
     /**
      * Add features to map request
@@ -69,8 +69,8 @@ declare module 'oskari-rpc' {
               color: string;
             };
           };
-        }
-      ]
+        },
+      ],
     ) => void;
 
     /**
@@ -85,8 +85,8 @@ declare module 'oskari-rpc' {
         },
         featureFilter: {
           [key: string]: string[];
-        }
-      ]
+        },
+      ],
     ) => void;
 
     /**
@@ -97,8 +97,8 @@ declare module 'oskari-rpc' {
       params: [
         featureFilterKey: string,
         featureFilterValue: string | number,
-        layerId: string
-      ]
+        layerId: string,
+      ],
     ) => void;
 
     /**
@@ -115,8 +115,8 @@ declare module 'oskari-rpc' {
           offsetY: number;
           size: number;
         },
-        id: string
-      ]
+        id: string,
+      ],
     ) => void;
 
     /**
@@ -124,7 +124,7 @@ declare module 'oskari-rpc' {
      */
     export type RemoveMarkersRequest = (
       name: 'MapModulePlugin.RemoveMarkersRequest',
-      params: number[]
+      params: number[],
     ) => void;
   }
 
@@ -162,8 +162,8 @@ declare module 'oskari-rpc' {
             },
         options: {
           hidePrevious?: boolean;
-        }
-      ]
+        },
+      ],
     ) => void;
 
     /**
@@ -171,7 +171,7 @@ declare module 'oskari-rpc' {
      */
     export type HideInfoBoxRequest = (
       name: 'InfoBox.HideInfoBoxRequest',
-      params: [id: string]
+      params: [id: string],
     ) => void;
   }
 
@@ -227,7 +227,7 @@ declare module 'oskari-rpc' {
      */
     export type DrawingEvent = (
       name: 'DrawingEvent',
-      callback: DrawingEventHandler
+      callback: DrawingEventHandler,
     ) => void;
 
     /**
@@ -235,7 +235,7 @@ declare module 'oskari-rpc' {
      */
     export type FeatureEvent = (
       name: 'FeatureEvent',
-      callback: FeatureEventHandler
+      callback: FeatureEventHandler,
     ) => void;
 
     /**
@@ -243,7 +243,7 @@ declare module 'oskari-rpc' {
      */
     export type MarkerClickEvent = (
       name: 'MarkerClickEvent',
-      callback: MarkerClickEventHandler
+      callback: MarkerClickEventHandler,
     ) => void;
 
     /**
@@ -251,7 +251,7 @@ declare module 'oskari-rpc' {
      */
     export type InfoboxActionEvent = (
       name: 'InfoboxActionEvent',
-      callback: InfoboxActionEventHandler
+      callback: InfoboxActionEventHandler,
     ) => void;
   }
 
@@ -287,7 +287,7 @@ declare module 'oskari-rpc' {
      */
     unregisterEventHandler: (
       name: string,
-      handler: (...args: any) => void
+      handler: (...args: any) => void,
     ) => void;
   }
 
@@ -312,6 +312,10 @@ declare module 'oskari-rpc' {
      * Name of the map layer
      */
     name: string;
+    /**
+     * Is the layer visible?
+     */
+    visible: boolean;
   }
 
   export interface Synchronizer {
@@ -328,11 +332,11 @@ declare module 'oskari-rpc' {
   const OskariRPC: {
     connect: (
       iframeElement: HTMLIFrameElement,
-      iframeDomain: string
+      iframeDomain: string,
     ) => Channel;
     synchronizerFactory: (
       channel: Channel,
-      handlers: Handler[]
+      handlers: Handler[],
     ) => Synchronizer;
     VERSION: string;
   };

--- a/interfaces/survey.d.ts
+++ b/interfaces/survey.d.ts
@@ -492,6 +492,7 @@ export type SurveyMapSubQuestionAnswer = AnswerEntry & {
  */
 export interface MapQuestionAnswer {
   selectionType: MapQuestionSelectionType;
+  mapLayers: number[];
   geometry: GeoJSONWithCRS<
     GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon>
   >;

--- a/server/migrations/1690881859529_answer-entry-map-layers.ts
+++ b/server/migrations/1690881859529_answer-entry-map-layers.ts
@@ -1,0 +1,7 @@
+import { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`ALTER TABLE data.answer_entry ADD COLUMN map_layers int[]`);
+}

--- a/server/src/application/map.ts
+++ b/server/src/application/map.ts
@@ -1,0 +1,45 @@
+import { MapLayer } from '@interfaces/survey';
+import fetch, { Response } from 'node-fetch';
+import { NotFoundError } from '../error';
+
+export async function getAvailableMapLayers(mapUrl: string) {
+  // Separate query parameters and possible trailing slash
+  const [baseUrl, queryParams] = mapUrl.split(/\/?\?/);
+  try {
+    const response: Response = await fetch(
+      `${baseUrl}/action?action_route=GetAppSetup&${queryParams}`
+    );
+    const responseJson = (await response.json()) as {
+      configuration: {
+        mapfull: {
+          conf: {
+            layers: MapLayer[];
+          };
+        };
+      };
+    };
+    const layers = responseJson.configuration?.mapfull?.conf?.layers?.map(
+      ({ id, name }) => ({
+        id,
+        name:
+          typeof name === 'string'
+            ? name
+            : // For user-created datasets, the name might be a localized object instead of a string.
+            // In this case, just pick the first one available
+            Object.keys(name).length > 0
+            ? name[Object.keys(name)[0]]
+            : '<untitled layer>',
+      })
+    );
+    // For non-existent UUIDs the full layer path won't exist in the response object
+    if (!layers) {
+      throw new NotFoundError('Map not found');
+    }
+    return layers;
+  } catch (error) {
+    if (error.code === 'ENOTFOUND') {
+      throw new NotFoundError('Map not found');
+    }
+    throw error;
+  }
+}

--- a/server/src/application/screenshot.ts
+++ b/server/src/application/screenshot.ts
@@ -7,6 +7,7 @@ import { Feature, LineString, Point, Polygon } from 'geojson';
 import parseCSSColor from 'parse-css-color';
 import { Page } from 'puppeteer';
 import { Cluster } from 'puppeteer-cluster';
+import { getAvailableMapLayers } from './map';
 
 /**
  * Oskari needs to be declared, because it is available as a global variable inside
@@ -35,6 +36,7 @@ export interface ScreenshotJobReturnData {
   sectionId: number;
   index: number;
   image: Buffer;
+  layerNames: string[];
 }
 
 // Default feature style
@@ -94,6 +96,8 @@ async function generateScreenshots({
 }) {
   const { mapUrl, answers } = data;
   const returnData: ScreenshotJobReturnData[] = [];
+
+  const availableMapLayers = await getAvailableMapLayers(mapUrl);
 
   // Setting a real user agent _might_ make requests flow faster
   await page.setUserAgent(
@@ -195,6 +199,12 @@ async function generateScreenshots({
       sectionId: answer.sectionId,
       index: answer.index,
       image,
+      layerNames: answer.visibleLayerIds
+        .map(
+          (layerId) =>
+            availableMapLayers.find((layer) => layer.id === layerId)?.name
+        )
+        .filter(Boolean),
     });
   }
 

--- a/server/src/application/submission.ts
+++ b/server/src/application/submission.ts
@@ -34,6 +34,7 @@ interface DBAnswerEntry {
   parent_entry_id: number;
   value_file: string;
   value_file_name: string;
+  map_layers: number[];
 }
 
 /**
@@ -61,6 +62,7 @@ const answerEntryColumnSet = (inputSRID: number) =>
     'parent_entry_id',
     'value_file',
     'value_file_name',
+    'map_layers',
   ]);
 
 /**
@@ -297,6 +299,7 @@ function answerEntriesToRows(
             value_json: null,
             value_file: null,
             value_file_name: null,
+            map_layers: null,
           },
         ];
         break;
@@ -314,6 +317,7 @@ function answerEntriesToRows(
             value_json: null,
             value_file: null,
             value_file_name: null,
+            map_layers: null,
           },
         ];
         break;
@@ -334,6 +338,7 @@ function answerEntriesToRows(
                     value_json: null,
                     value_file: null,
                     value_file_name: null,
+                    map_layers: null,
                   };
                 }),
               ]
@@ -349,6 +354,7 @@ function answerEntriesToRows(
                   value_json: null,
                   value_file: null,
                   value_file_name: null,
+                  map_layers: null,
                 },
               ];
         break;
@@ -365,6 +371,7 @@ function answerEntriesToRows(
             value_json: null,
             value_file: null,
             value_file_name: null,
+            map_layers: null,
           },
         ];
         break;
@@ -381,6 +388,7 @@ function answerEntriesToRows(
             value_json: null,
             value_file: null,
             value_file_name: null,
+            map_layers: value.mapLayers,
             // Save subquestion answers under the entry for inserting them with correct parent entry ID later on
             subQuestionAnswers: value.subQuestionAnswers,
           };
@@ -400,6 +408,7 @@ function answerEntriesToRows(
             value_json: JSON.stringify(entry.value),
             value_file: null,
             value_file_name: null,
+            map_layers: null,
           },
         ];
         break;
@@ -416,6 +425,7 @@ function answerEntriesToRows(
             value_json: null,
             value_file: null,
             value_file_name: null,
+            map_layers: null,
           },
         ];
         break;
@@ -432,6 +442,7 @@ function answerEntriesToRows(
             value_json: JSON.stringify(entry.value),
             value_file: null,
             value_file_name: null,
+            map_layers: null,
           },
         ];
         break;
@@ -448,6 +459,7 @@ function answerEntriesToRows(
             value_json: null,
             value_file: value.fileString,
             value_file_name: value.fileName,
+            map_layers: null,
           })) ?? [];
     }
 
@@ -561,6 +573,7 @@ function dbAnswerEntriesToAnswerEntries(
               geometry: row.value_geometry,
               properties: {},
             },
+            mapLayers: row.map_layers,
             // The function should only return map subquestion answers because of filtering - assume the type here
             subQuestionAnswers: dbAnswerEntriesToAnswerEntries(
               rows,
@@ -655,6 +668,7 @@ export async function getUnfinishedAnswerEntries(token: string) {
       ae.value_json,
       ae.value_file,
       ae.value_file_name,
+      ae.map_layers,
       ps.type AS section_type,
       ps.parent_section AS parent_section
     FROM
@@ -700,6 +714,7 @@ export async function getAnswerEntries(submissionId: number) {
       ae.value_json,
       ae.value_file,
       ae.value_file_name,
+      ae.map_layers,
       ps.type AS section_type,
       ps.parent_section AS parent_section
     FROM

--- a/server/src/routes/map.routes.ts
+++ b/server/src/routes/map.routes.ts
@@ -1,11 +1,9 @@
-import { MapLayer } from '@interfaces/survey';
 import { ensureAuthenticated } from '@src/auth';
-import { NotFoundError } from '@src/error';
 import { validateRequest } from '@src/utils';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { query } from 'express-validator';
-import fetch, { Response } from 'node-fetch';
+import { getAvailableMapLayers } from '../application/map';
 
 const router = Router();
 
@@ -15,45 +13,8 @@ router.get(
   validateRequest([query('url').isString()]),
   asyncHandler(async (req, res) => {
     const mapUrl = decodeURIComponent(req.query.url.toString());
-    // Separate query parameters and possible trailing slash
-    const [baseUrl, queryParams] = mapUrl.split(/\/?\?/);
-    try {
-      const response: Response = await fetch(
-        `${baseUrl}/action?action_route=GetAppSetup&${queryParams}`
-      );
-      const responseJson = (await response.json()) as {
-        configuration: {
-          mapfull: {
-            conf: {
-              layers: MapLayer[];
-            };
-          };
-        };
-      };
-      const layers = responseJson.configuration?.mapfull?.conf?.layers?.map(
-        ({ id, name }) => ({
-          id,
-          name:
-            typeof name === 'string'
-              ? name
-              : // For user-created datasets, the name might be a localized object instead of a string.
-              // In this case, just pick the first one available
-              Object.keys(name).length > 0
-              ? name[Object.keys(name)[0]]
-              : '<untitled layer>',
-        })
-      );
-      // For non-existent UUIDs the full layer path won't exist in the response object
-      if (!layers) {
-        throw new NotFoundError('Map not found');
-      }
-      res.json(layers);
-    } catch (error) {
-      if (error.code === 'ENOTFOUND') {
-        throw new NotFoundError('Map not found');
-      }
-      throw error;
-    }
+    const layers = await getAvailableMapLayers(mapUrl);
+    res.json(layers);
   })
 );
 


### PR DESCRIPTION
- Added map layers to the frontend state: whenever a page is turned, frontend will remember which layers were selected on each page and restores them back to view.
- When submitting answers, each map answer gets amended with the selected map layers
- In the PDF report the selected map layers are used for the screenshots, and their names are displayed
- Improved PDF report styles