### PR TITLE
Updated Node.js version to 20

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '20'
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '20'
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ###
 # Base image declaration
 ###
-FROM node:14.17.1-alpine AS base
+FROM node:20.5-alpine AS base
 
 ENV APPDIR /app
 

--- a/client/Dockerfile.develop
+++ b/client/Dockerfile.develop
@@ -2,7 +2,7 @@
 # Development image for client dev server
 ##
 
-FROM node:14.17.1-alpine
+FROM node:20.5-alpine
 
 # Define Git directory and install Git for running Jest only on changed files
 ENV GIT_WORK_TREE=/app/client

--- a/client/package.json
+++ b/client/package.json
@@ -7,10 +7,10 @@
     "test": "jest --config ./jest.config.json",
     "test:watch": "npm run test -- --watch",
     "lint": "eslint . --ext .ts,.tsx",
-    "dev": "webpack serve --config webpack.dev.js",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider webpack serve --config webpack.dev.js",
     "start": "node server.js",
     "prebuild": "npm run lint && npm run test",
-    "build": "webpack --config webpack.prod.js"
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --config webpack.prod.js"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/ubigu/vuorovaikutusalusta#readme",
   "engines": {
-    "node": "^14.17.1"
+    "node": "^20.5.0"
   },
   "dependencies": {
     "@date-io/date-fns": "^2.11.0",

--- a/server/Dockerfile.develop
+++ b/server/Dockerfile.develop
@@ -2,7 +2,7 @@
 # Development image for Node.js server
 ##
 
-FROM node:14.17.1-alpine
+FROM node:20.5-alpine
 
 # Define Git directory and install Git for running Jest only on changed files
 ENV GIT_WORK_TREE=/app/server
@@ -10,7 +10,7 @@ ENV GIT_DIR=/app/.git
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+  PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 RUN apk update && apk add \
   git \

--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/ubigu/vuorovaikutusalusta#readme",
   "engines": {
-    "node": "^14.17.1"
+    "node": "^20.5.0"
   },
   "dependencies": {
     "@types/async-retry": "^1.4.2",


### PR DESCRIPTION
Updated Node.js version from 14 to 20.

Webpack doesn't seem to be compatible with Node.js version >=17 because of changes to OpenSSL provider in Node.js - this is worked around by adding the environment variable `NODE_OPTIONS=--openssl-legacy-provider` to Webpack commands.