### PR TITLE
Improve dialog accessibility

### DIFF
--- a/client/src/components/CheckBoxQuestion.tsx
+++ b/client/src/components/CheckBoxQuestion.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 const customAnswerMaxLength = 100;
 
 interface Props {
+  autoFocus?: boolean;
   value: (string | number)[];
   onChange: (value: (string | number)[]) => void;
   question: SurveyCheckboxQuestion;
@@ -24,6 +25,7 @@ interface Props {
 }
 
 export default function CheckBoxQuestion({
+  autoFocus = false,
   value,
   onChange,
   question,
@@ -80,12 +82,13 @@ export default function CheckBoxQuestion({
           setDirty(true);
         }}
       >
-        {question.options.map((option) => (
+        {question.options.map((option, index) => (
           <FormControlLabel
             key={option.id}
             label={option.text?.[surveyLanguage] ?? ''}
             control={
               <Checkbox
+                autoFocus={index === 0 && autoFocus}
                 // TS can't infer the precise memoized value type from question.type, but for checkboxes it's always an array
                 checked={value.includes(option.id)}
                 onChange={(event) => {

--- a/client/src/components/CheckBoxQuestion.tsx
+++ b/client/src/components/CheckBoxQuestion.tsx
@@ -137,9 +137,10 @@ export default function CheckBoxQuestion({
           <TextField
             value={customAnswerValue}
             required={question.isRequired}
+            placeholder={tr.SurveyQuestion.customAnswerField}
             inputProps={{
               maxLength: customAnswerMaxLength,
-              'aria-label': tr.SurveyQuestion.customAnswer,
+              'aria-label': tr.SurveyQuestion.customAnswerField,
             }}
             onChange={(event) => {
               setCustomAnswerValue(event.currentTarget.value);

--- a/client/src/components/ConfirmDialog.tsx
+++ b/client/src/components/ConfirmDialog.tsx
@@ -42,10 +42,20 @@ export default function ConfirmDialog(props: Props) {
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose(false)} autoFocus>
+        <Button
+          autoFocus
+          variant="outlined"
+          onClick={handleClose(false)}
+        >
           {tr.options.no}
         </Button>
-        <Button onClick={handleClose(true)}>{tr.options.yes}</Button>
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={handleClose(true)}
+        >
+          {tr.options.yes}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/client/src/components/FreeTextQuestion.tsx
+++ b/client/src/components/FreeTextQuestion.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from '@src/stores/TranslationContext';
 import React from 'react';
 
 interface Props {
+  autoFocus?: boolean;
   question: SurveyFreeTextQuestion;
   value: string;
   onChange: (value: string) => void;
@@ -12,6 +13,7 @@ interface Props {
 }
 
 export default function FreeTextQuestion({
+  autoFocus = false,
   question,
   value,
   onChange,
@@ -22,6 +24,7 @@ export default function FreeTextQuestion({
   return (
     <>
       <TextField
+        autoFocus={autoFocus}
         value={value}
         multiline
         required={question.isRequired}

--- a/client/src/components/MapSubQuestionDialog.tsx
+++ b/client/src/components/MapSubQuestionDialog.tsx
@@ -116,11 +116,9 @@ export default function MapSubQuestionDialog({
       open={open}
       onClose={onCancel}
       aria-label={tr.MapQuestion.subQuestionDialog}
-      aria-describedby="subquestion-dialog-content"
     >
       {title && <DialogTitle>{title}</DialogTitle>}
       <DialogContent
-        id="subquestion-dialog-content"
         className={classes.content}
       >
         {subQuestions?.map((question, index) => (
@@ -130,6 +128,9 @@ export default function MapSubQuestionDialog({
             error={dirty?.[index] && validationErrors?.[index].length > 0}
             style={{ width: '100%' }}
           >
+            <FormLabel component="legend">
+              {question.title?.[surveyLanguage]} {question.isRequired && '*'}
+            </FormLabel>
             <div
               style={{
                 display: 'flex',
@@ -137,9 +138,6 @@ export default function MapSubQuestionDialog({
                 alignItems: 'center',
               }}
             >
-              <FormLabel htmlFor={`${question.id}-input`}>
-                {question.title?.[surveyLanguage]} {question.isRequired && '*'}
-              </FormLabel>
               {question.info && question.info?.[surveyLanguage] && (
                 <SectionInfo
                   infoText={question.info?.[surveyLanguage]}
@@ -149,6 +147,7 @@ export default function MapSubQuestionDialog({
             </div>
             {question.type === 'checkbox' ? (
               <CheckBoxQuestion
+                autoFocus={index === 0}
                 value={answers[index]?.value as (number | string)[]}
                 onChange={(value) => {
                   answers[index].value = value;
@@ -162,6 +161,7 @@ export default function MapSubQuestionDialog({
               />
             ) : question.type === 'radio' ? (
               <RadioQuestion
+                autoFocus={index === 0}
                 value={answers[index]?.value as number | string}
                 onChange={(value) => {
                   answers[index].value = value;
@@ -175,6 +175,7 @@ export default function MapSubQuestionDialog({
               />
             ) : question.type === 'free-text' ? (
               <FreeTextQuestion
+                autoFocus={index === 0}
                 value={answers[index]?.value as string}
                 onChange={(value) => {
                   answers[index].value = value;
@@ -189,6 +190,7 @@ export default function MapSubQuestionDialog({
               />
             ) : question.type === 'numeric' ? (
               <NumericQuestion
+                autoFocus={index === 0}
                 value={answers[index]?.value as number}
                 onChange={(value) => {
                   answers[index].value = value;

--- a/client/src/components/MapSubQuestionDialog.tsx
+++ b/client/src/components/MapSubQuestionDialog.tsx
@@ -219,13 +219,14 @@ export default function MapSubQuestionDialog({
             onClick={() => {
               onDelete();
             }}
-            variant="contained"
+            color="error"
           >
             {tr.MapQuestion.removeAnswer}
           </Button>
         )}
         <div style={{ flexGrow: 1 }} />
         <Button
+          variant="outlined"
           onClick={() => {
             onCancel();
           }}
@@ -233,6 +234,7 @@ export default function MapSubQuestionDialog({
           {tr.commands.cancel}
         </Button>
         <Button
+          variant="contained"
           onClick={() => {
             onSubmit(answers);
           }}

--- a/client/src/components/NumericQuestion.tsx
+++ b/client/src/components/NumericQuestion.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from '@src/stores/TranslationContext';
 import React from 'react';
 
 interface Props {
+  autoFocus?: boolean;
   question: SurveyNumericQuestion;
   value: number;
   onChange: (value: number) => void;
@@ -11,6 +12,7 @@ interface Props {
 }
 
 export default function NumericQuestion({
+  autoFocus = false,
   question,
   value,
   onChange,
@@ -21,6 +23,7 @@ export default function NumericQuestion({
   return (
     <>
       <TextField
+        autoFocus={autoFocus}
         value={value ?? ''}
         required={question.isRequired}
         inputProps={{

--- a/client/src/components/RadioQuestion.tsx
+++ b/client/src/components/RadioQuestion.tsx
@@ -80,9 +80,10 @@ export default function RadioQuestion({
               <TextField
                 value={customAnswerValue}
                 required={question.isRequired}
+                placeholder={tr.SurveyQuestion.customAnswerField}
                 inputProps={{
                   maxLength: customAnswerMaxLength,
-                  'aria-label': tr.SurveyQuestion.customAnswer,
+                  'aria-label': tr.SurveyQuestion.customAnswerField,
                 }}
                 onChange={(event) => {
                   setCustomAnswerValue(event.currentTarget.value);

--- a/client/src/components/RadioQuestion.tsx
+++ b/client/src/components/RadioQuestion.tsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles({
 const customAnswerMaxLength = 100;
 
 interface Props {
+  autoFocus?: boolean;
   value: number | string;
   onChange: (value: number | string) => void;
   question: SurveyRadioQuestion;
@@ -25,6 +26,7 @@ interface Props {
 }
 
 export default function RadioQuestion({
+  autoFocus = false,
   value,
   onChange,
   question,
@@ -57,12 +59,12 @@ export default function RadioQuestion({
         }}
         name={`${question.title?.[surveyLanguage]}-group`}
       >
-        {question.options.map((option) => (
+        {question.options.map((option, index) => (
           <FormControlLabel
             key={option.id}
             value={option.id}
             label={option.text?.[surveyLanguage] ?? ''}
-            control={<Radio />}
+            control={<Radio autoFocus={index === 0 && autoFocus} />}
             classes={{ label: classes.labelStyles }}
           />
         ))}

--- a/client/src/components/SaveAsUnfinishedDialog.tsx
+++ b/client/src/components/SaveAsUnfinishedDialog.tsx
@@ -126,7 +126,11 @@ export default function SaveAsUnfinishedDialog({
         >
           {tr.commands.cancel}
         </Button>
-        <Button onClick={handleSave} disabled={loading || !email.length}>
+        <Button
+          variant='contained'
+          onClick={handleSave}
+          disabled={loading || !email.length}
+        >
           {tr.options.ok}
         </Button>
       </DialogActions>

--- a/client/src/components/SaveAsUnfinishedDialog.tsx
+++ b/client/src/components/SaveAsUnfinishedDialog.tsx
@@ -83,21 +83,27 @@ export default function SaveAsUnfinishedDialog({
     <Dialog
       open={open}
       onClose={() => {
+        setEmailDirty(false);
         onCancel();
       }}
+      aria-describedby='save-dialog-content'
     >
       <DialogTitle>{tr.SurveyStepper.saveAsUnfinished}</DialogTitle>
       <DialogContent>
-        <Typography variant="body1" className={classes.paragraph}>
-          {tr.SaveAsUnfinishedDialog.description}
-        </Typography>
-        <Typography variant="body1" className={classes.paragraph}>
-          {tr.SaveAsUnfinishedDialog.disclaimer}
-        </Typography>
+        <div id='save-dialog-content'>
+          <Typography variant="body1" className={classes.paragraph}>
+            {tr.SaveAsUnfinishedDialog.description}
+          </Typography>
+          <Typography variant="body1" className={classes.paragraph}>
+            {tr.SaveAsUnfinishedDialog.disclaimer}
+          </Typography>
+        </div>
         <TextField
+          autoFocus
           aria-label={tr.SaveAsUnfinishedDialog.email}
           label={tr.SaveAsUnfinishedDialog.email}
           required
+          name='email'
           error={emailDirty && !email.length}
           value={email}
           inputProps={{ type: 'email' }}
@@ -111,7 +117,13 @@ export default function SaveAsUnfinishedDialog({
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel} disabled={loading}>
+        <Button
+          onClick={() => {
+            setEmailDirty(false);
+            onCancel();
+          }}
+          disabled={loading}
+        >
           {tr.commands.cancel}
         </Button>
         <Button onClick={handleSave} disabled={loading || !email.length}>

--- a/client/src/components/SectionInfo.tsx
+++ b/client/src/components/SectionInfo.tsx
@@ -11,6 +11,7 @@ import { Help as HelpIcon } from '@mui/icons-material';
 import ReactMarkdown from 'react-markdown';
 import rehypeExternalLinks from 'rehype-external-links';
 import { useTranslations } from '@src/stores/TranslationContext';
+import useId from '@mui/material/utils/useId';
 
 interface Props {
   subject: string;
@@ -27,6 +28,7 @@ export default function SectionInfo({
 }: Props) {
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const { tr } = useTranslations();
+  const dialogId = useId();
 
   return (
     <div style={style ?? {}} aria-hidden={hiddenFromScreenReader}>
@@ -38,18 +40,19 @@ export default function SectionInfo({
           <HelpIcon color="primary" fontSize="medium" />
         </IconButton>
       </Tooltip>
-      <Dialog onClose={() => setInfoDialogOpen(false)} open={infoDialogOpen}>
-        <DialogContent
-          tabIndex={0}
-          aria-label={`${tr.SurveyQuestion.info}: ${subject}`}
-        >
+      <Dialog
+        aria-describedby={`${dialogId}-dialog-content`}
+        onClose={() => setInfoDialogOpen(false)}
+        open={infoDialogOpen}
+      >
+        <DialogContent id={`${dialogId}-dialog-content`}>
           <ReactMarkdown rehypePlugins={[rehypeExternalLinks]}>
             {infoText}
           </ReactMarkdown>
         </DialogContent>
         <DialogActions>
           <Button
-            tabIndex={1}
+            autoFocus
             color="primary"
             variant="contained"
             onClick={() => setInfoDialogOpen(false)}

--- a/client/src/components/SurveyMap.tsx
+++ b/client/src/components/SurveyMap.tsx
@@ -2,6 +2,7 @@ import { Fab, Tooltip } from '@mui/material';
 import { Check, Edit } from '@mui/icons-material';
 import { useSurveyMap } from '@src/stores/SurveyMapContext';
 import { useTranslations } from '@src/stores/TranslationContext';
+import { visuallyHidden } from '@mui/utils';
 import OskariRPC from 'oskari-rpc';
 import React, { useEffect, useRef } from 'react';
 
@@ -68,8 +69,13 @@ export default function SurveyMap(props: Props) {
   return (
     props.url && (
       <>
+        <p style={visuallyHidden}>
+          {tr.SurveyMap.browsingInstructions}
+        </p>
         <iframe
           ref={iframeRef}
+          title={tr.SurveyMap.iFrameTitle}
+          aria-describedby="mapEmbedInstructions"
           style={{
             border: 0,
             width: '100%',

--- a/client/src/stores/en.json
+++ b/client/src/stores/en.json
@@ -348,7 +348,8 @@
     "answerLimitsMinMax": "Choose a minimum of {min} and a maximum of {max} options",
     "answerLimitsMin": "Choose a minimum of {min} options",
     "answerLimitsMax": "Choose a maximum of {max} options",
-    "customAnswer": "Something else, what?",
+    "customAnswer": "Other (specify below)",
+    "customAnswerField": "Specify your answer here.",
     "charactersRemaining": "{x} character(s) left.",
     "showInfo": "Show additional information",
     "info": "Additional information"

--- a/client/src/stores/en.json
+++ b/client/src/stores/en.json
@@ -372,8 +372,10 @@
     "confirmRemoveAnswer": "Are you sure you want to delete this answer?"
   },
   "SurveyMap": {
+    "browsingInstructions": "Pan the map view with the arrow keys, zoom in and out using plus and minus keys.",
     "editGeometries": "Modify your previous map answers",
-    "finishEditingGeometries": "Stop modifying map answers"
+    "finishEditingGeometries": "Stop modifying map answers",
+    "iFrameTitle": "Map view"
   },
   "MatrixQuestion": {
     "emptyAnswer": "I don't know",

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -372,8 +372,10 @@
     "confirmRemoveAnswer": "Haluatko varmasti poistaa tämän karttavastauksen?"
   },
   "SurveyMap": {
+    "browsingInstructions": "Liikuta karttanäkymää nuolinäppäimillä. Lähennä ja loitonna plus- ja miinusnäppäimillä.",
     "editGeometries": "Muokkaa piirtämiäsi karttamerkintöjä",
-    "finishEditingGeometries": "Lopeta karttamerkintöjen muokkaus"
+    "finishEditingGeometries": "Lopeta karttamerkintöjen muokkaus",
+    "iFrameTitle": "Karttanäkymä"
   },
   "MatrixQuestion": {
     "emptyAnswer": "En osaa sanoa",

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -348,7 +348,8 @@
     "answerLimitsMinMax": "Valitse vähintään {min}, enintään {max} vaihtoehtoa",
     "answerLimitsMin": "Valitse vähintään {min} vaihtoehtoa",
     "answerLimitsMax": "Valitse enintään {max} vaihtoehtoa",
-    "customAnswer": "Jokin muu, mikä?",
+    "customAnswer": "Jokin muu (täsmennä alla)",
+    "customAnswerField": "Täsmennä vastaustasi tässä.",
     "charactersRemaining": "{x} merkki(ä) jäljellä.",
     "showInfo": "Näytä lisätietoja",
     "info": "Lisätietoja"


### PR DESCRIPTION
Dialogs containing input had some accessibility shortcomings. This PR includes improvements to labelling, styling, naming, placeholders and interactions.
Also implemented an autoFocus prop for map subquestion types.
Closes #90 