### PR TITLE
Improve contrasts and overall state visibility

### DIFF
--- a/client/src/components/AttachmentQuestion.tsx
+++ b/client/src/components/AttachmentQuestion.tsx
@@ -41,7 +41,7 @@ export default function AttachmentQuestion({
 
   const dropzoneContent = value?.length ? (
     <div>
-      <Typography> {tr.AttachmentQuestion.addedFile}: </Typography>
+      <Typography color='info'> {tr.AttachmentQuestion.addedFile}: </Typography>
       {value?.map((file, index) => {
         return (
           <div
@@ -52,7 +52,7 @@ export default function AttachmentQuestion({
               alignItems: 'center',
             }}
           >
-            <Typography style={{ color: 'purple' }}>
+            <Typography color='primary' >
               {' '}
               {file.fileName}{' '}
             </Typography>

--- a/client/src/components/DropZone.tsx
+++ b/client/src/components/DropZone.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { useTranslations } from '@src/stores/TranslationContext';
 import React, { useEffect } from 'react';
@@ -18,6 +19,16 @@ const useStyles = makeStyles({
     borderStyle: 'dashed',
     backgroundColor: '#fafafa',
     transition: 'border .24s ease-in-out',
+  },
+  dropzone: {
+    borderRadius: '2px',
+    outlineOffset: 0,
+    outlineColor: 'rbga(0,0,0,0)',
+    transition: 'outline-offset 400ms, outline-color   400ms',
+    '&:focus-visible': {
+      outline: '2px solid black',
+      outlineOffset: '2px',
+    }
   },
 });
 
@@ -41,10 +52,13 @@ export default function DropZone({ maxFiles, fileCallback, children }: Props) {
 
   return (
     <section className={classes.container}>
-      <div {...getRootProps({ className: 'dropzone' })}>
+      <div
+        {...getRootProps({ className: `dropzone ${classes.dropzone}` })}
+        aria-label={children ? tr.AttachmentQuestion.replace : '' }
+      >
         <input {...getInputProps()} />
-        <div style={{ color: 'purple', cursor: 'pointer' }}>
-          {children ? children : tr.DropZone.dropFiles}
+        <div style={{ cursor: 'pointer' }}>
+          <Typography color='primary'>{children ? children : tr.DropZone.dropFiles}</Typography>
         </div>
       </div>
     </section>

--- a/client/src/components/SaveAsUnfinishedDialog.tsx
+++ b/client/src/components/SaveAsUnfinishedDialog.tsx
@@ -114,6 +114,11 @@ export default function SaveAsUnfinishedDialog({
           onBlur={() => {
             setEmailDirty(true);
           }}
+          sx={{
+            '& .Mui-focused': {
+              outlineOffset: '.5em', // Outline obstructs label otherwise
+            }
+          }}
         />
       </DialogContent>
       <DialogActions>

--- a/client/src/components/SaveAsUnfinishedDialog.tsx
+++ b/client/src/components/SaveAsUnfinishedDialog.tsx
@@ -115,7 +115,7 @@ export default function SaveAsUnfinishedDialog({
             setEmailDirty(true);
           }}
           sx={{
-            '& .Mui-focused': {
+            '& .MuiOutlinedInput-root.Mui-focused': {
               outlineOffset: '.5em', // Outline obstructs label otherwise
             }
           }}

--- a/client/src/components/SliderQuestion.tsx
+++ b/client/src/components/SliderQuestion.tsx
@@ -16,9 +16,6 @@ const useStyles = makeStyles({
   label: {
     cursor: 'pointer',
   },
-  emptyValue: {
-    color: '#ccc',
-  },
 });
 
 export default function SliderQuestion({
@@ -82,7 +79,6 @@ export default function SliderQuestion({
       <Slider
         aria-label={question.title?.[surveyLanguage]}
         ref={sliderRef}
-        className={value === null ? classes.emptyValue : ''}
         slotProps={{
           input: {
             'aria-describedby': `${question.id}-value-label`,
@@ -97,6 +93,14 @@ export default function SliderQuestion({
         getAriaValueText={(v) => v.toString()}
         step={1}
         marks
+        sx={{
+          '.MuiSlider-track, .MuiSlider-rail': {
+            color: value === null ? '#ccc' : 'inherit',
+          },
+          '.MuiSlider-mark': {
+            color: value === null ? 'white' : 'inherit',
+          },
+        }}
         onClick={() => {
           if (value === null) {
             onChange(visibleEmptyValue);

--- a/client/src/components/SortingQuestion.tsx
+++ b/client/src/components/SortingQuestion.tsx
@@ -114,7 +114,12 @@ export default function SortingQuestion(props: Props) {
                         justifyContent: "space-between",
                         marginBottom: "0.5em",
                         padding: "0.5em",
-                        transition: "background-color 200ms",}}
+                        transition: "background-color 200ms",
+                        '&:focus': {
+                          outlineOffset: "2px",
+                          outline: "2px solid black",
+                        }
+                      }}
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                       ref={provided.innerRef}

--- a/client/src/components/SurveyLandingPage.tsx
+++ b/client/src/components/SurveyLandingPage.tsx
@@ -1,5 +1,6 @@
 import { Survey } from '@interfaces/survey';
-import { Box, Link, Theme, Typography } from '@mui/material';
+import { Scale } from '@mui/icons-material';
+import { Box, Button, Link, Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { useTranslations } from '@src/stores/TranslationContext';
 import { getClassList } from '@src/utils/classes';
@@ -38,7 +39,7 @@ const useStyles = makeStyles((theme: Theme & { [customKey: string]: any }) => ({
     textAlign: 'center',
     fontWeight: 800,
     lineHeight: 1.5,
-    margin: '1rem',
+    margin: '2rem',
     '& span': {
       backgroundColor: theme.palette.primary.main,
       color: theme.palette.primary.contrastText,
@@ -74,13 +75,13 @@ const useStyles = makeStyles((theme: Theme & { [customKey: string]: any }) => ({
     color: theme.palette.secondary.contrastText,
     padding: '0.5rem',
     textDecoration: 'none',
-    marginTop: '1.5rem',
+    transition: 'transform 200ms ease-out',
     '&:hover': {
-      // TODO: hover effect for start button?
+      transform: 'scale(1.1)',
     },
     ...theme.landingPage?.start,
     [theme.breakpoints.down(600)]: {
-      fontSize: '6vw',
+      fontSize: '6vw',    
     },
   },
   footer: {
@@ -154,24 +155,29 @@ export default function SurveyLandingPage({
           flexGrow: 1,
         }}
       >
-        <h1 className={getClassList([classes.heading, classes.title])}>
-          <span>{survey.title?.[surveyLanguage]}</span>
-        </h1>
-        {survey.subtitle?.[surveyLanguage] && (
-          <h2 className={getClassList([classes.heading, classes.subtitle])}>
-            <span>{survey.subtitle?.[surveyLanguage]}</span>
-          </h2>
-        )}
-        <Link
-          component="button"
-          variant="body2"
-          className={classes.start}
+        <div>
+          <h1 className={getClassList([classes.heading, classes.title])}>
+            <span>{survey.title?.[surveyLanguage]}</span>
+          </h1>
+          {survey.subtitle?.[surveyLanguage] && (
+            <h2 className={getClassList([classes.heading, classes.subtitle])}>
+              <span>{survey.subtitle?.[surveyLanguage]}</span>
+            </h2>
+          )}
+        </div>
+        <Button
           onClick={onStart}
         >
-          {continueUnfinished
-            ? tr.SurveyPage.continueSurveyLink
-            : tr.SurveyPage.startSurveyLink}
-        </Link>
+          <Typography
+            variant="body1"
+            className={classes.start}
+          >
+            {continueUnfinished
+              ? tr.SurveyPage.continueSurveyLink
+              : tr.SurveyPage.startSurveyLink
+            }
+          </Typography>
+        </Button>
       </div>
       <div className={classes.footer}>
         <div className={classes.footerLogo}>

--- a/client/src/components/SurveyLanguageMenu.tsx
+++ b/client/src/components/SurveyLanguageMenu.tsx
@@ -35,7 +35,8 @@ export default function SurveyLanguageMenu({
         title={tr.SurveyLanguageMenu.changeSurveyLanguage}
       >
         <Select
-          inputProps={{"aria-label": tr.SurveyLanguageMenu.languageControl}}
+          inputProps={{ "aria-label": tr.SurveyLanguageMenu.languageControl }}
+          size='small'
           value={surveyLanguage}
           onChange={(event) => {
             const targetLanguage = event.target.value as LanguageCode;
@@ -48,9 +49,8 @@ export default function SurveyLanguageMenu({
             '&>.MuiSelect-select': { // Accommodate the larger globe icon
               paddingRight: '38px !important',
             },
-            '&>fieldset': { // Visual label not used, hide border and legend
-              borderWidth: 0,
-              '&>legend': {display: 'none'},
+            '&>fieldset': { 
+              display: 'none',
             },
             '& svg': { // The component is used in admin panel and survey, must adapt
               color: 'inherit',

--- a/client/src/components/SurveyStepper.tsx
+++ b/client/src/components/SurveyStepper.tsx
@@ -85,11 +85,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   stepActive: {
     fontSize: '1.1rem',
   },
-  stepIcon: {
-    '& text': {
-      fill: 'white !important' as any,
-    },
-  },
   stepIconUnfinised: {
     '& svg': {
       color: 'red',
@@ -354,7 +349,6 @@ export default function SurveyStepper({
                 classes={{
                   active: classes.stepActive,
                   label: classes.stepHeader,
-                  iconContainer: classes.stepIcon,
                 }}
               >
                 <Typography

--- a/client/src/stores/SurveyThemeProvider.tsx
+++ b/client/src/stores/SurveyThemeProvider.tsx
@@ -2,7 +2,7 @@ import { Survey } from '@interfaces/survey';
 import { createTheme, Theme } from '@mui/material';
 import { fiFI } from '@mui/material/locale';
 import { ThemeProvider } from '@mui/material/styles';
-import { buttonOverrides, defaultSurveyTheme } from '@src/themes/survey';
+import { buttonOverrides, defaultSurveyTheme, inputOverrides, stepperOverrides } from '@src/themes/survey';
 import React, { ReactNode, useContext, useMemo, useReducer } from 'react';
 
 /**
@@ -61,7 +61,7 @@ export function useSurveyTheme() {
             {
               ...survey.theme?.data,
               components: {
-                ...buttonOverrides,
+                ...buttonOverrides, ...inputOverrides, ...stepperOverrides,
               },
             },
             fiFI

--- a/client/src/stores/en.json
+++ b/client/src/stores/en.json
@@ -178,7 +178,8 @@
     "fileSizeLimitError": "File size cannot exceed 10MB",
     "unsupportedFileFormat": "Unsupported file format",
     "attachmentFileFormats": "Supported file formats: jpg, jpeg, png, pdf, docx, xlsx.",
-    "deleteUploadedFile": "Delete uploaded file"
+    "deleteUploadedFile": "Delete uploaded file",
+    "replace": "Replace the selected file by clicking here."
   },
   "SurveyImageList": {
     "attributions": "Copyright & attributions",

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -178,7 +178,8 @@
     "fileSizeLimitError": "Ladattavan tiedoston koko ei saa olla yli 10MB",
     "unsupportedFileFormat": "Tiedostoformaattia ei tueta",
     "attachmentFileFormats": "Sallitut tiedostoformaatit: jpg, jpeg, png, pdf, docx, xlsx.",
-    "deleteUploadedFile": "Poista ladattu tiedosto"
+    "deleteUploadedFile": "Poista ladattu tiedosto",
+    "replace": "Korvaa valittu liite napsauttamalla."
   },
   "SurveyImageList": {
     "attributions": "Tekijänoikeustiedot",

--- a/client/src/themes/survey.ts
+++ b/client/src/themes/survey.ts
@@ -1,18 +1,55 @@
-import { Theme, Components, createTheme, CSSInterpolation } from '@mui/material/styles';
+import { Theme, Components, createTheme, CSSInterpolation, useTheme } from '@mui/material/styles';
 import { fiFI } from '@mui/material/locale';
 
+const idleOutlineStyle: CSSInterpolation = {
+  outlineOffset: 0,
+  outlineColor: 'rgba(0,0,0,.0);',
+  transition: 'outline-offset 400ms, outline-color 400ms',
+}
+
+const disabledColor = '#636363';
+const focusBackground = '#40aeff2e';
+const defaultFocusOutlineShorthand = '2px solid black';
+
+const defaultFocusOutlineStyles: CSSInterpolation = {
+  outline: defaultFocusOutlineShorthand,
+  outlineOffset: '2px',
+}
+
+const defaultFocusStyles: CSSInterpolation = {
+  backgroundColor: focusBackground,
+  ...defaultFocusOutlineStyles,
+}
+
+const defaultFocus: CSSInterpolation = {
+  ...idleOutlineStyle,
+  '&.Mui-focusVisible': defaultFocusStyles,
+}
+
 export const buttonOverrides: Components<Omit<Theme, 'components'>> = {
+  MuiButtonBase: {
+    styleOverrides: {
+      root: {
+        ...idleOutlineStyle,
+        '&.Mui-focusVisible:not(.MuiButton-contained)': defaultFocusStyles,
+        '&.Mui-focusVisible.MuiButton-contained': defaultFocusOutlineStyles,
+        textTransform: 'none',
+        '&.Mui-disabled': {
+          color: disabledColor,
+        },
+      },
+    },
+    defaultProps: {
+      disableRipple: true,
+    }
+  },
   MuiButton: {
     styleOverrides: {
       root: {
         textTransform: 'none',
-      },
-    },
-  },
-  MuiButtonBase: {
-    styleOverrides: {
-      root: {
-        textTransform: 'none',
+        '&.Mui-disabled': {
+          color: disabledColor,
+        },
       },
     },
   },
@@ -25,46 +62,24 @@ export const buttonOverrides: Components<Omit<Theme, 'components'>> = {
   },
 };
 
-const idleOutlineStyle: CSSInterpolation = {
-  outlineOffset: 0,
-  outlineColor: 'rgba(0,0,0,.0);',
-  transition: 'outline-offset 400ms, outline-color 400ms',
-}
-
-const defaultFocusOutlineShorthand = '2px solid black';
-
-const defaultFocusStyles: CSSInterpolation = {
-  outline: defaultFocusOutlineShorthand,
-  outlineOffset: '2px',
-}
-
-const defaultFocus: CSSInterpolation = {
-  ...idleOutlineStyle,
-  '&.Mui-focusVisible': defaultFocusStyles,
-}
-
-export const focusOverrides: Components<Omit<Theme, 'components'>> = {
+export const inputOverrides: Components<Omit<Theme, 'components'>> = {
   MuiAccordionSummary: {
     styleOverrides: {
       root: {
         '&.Mui-focusVisible': {
+          background: focusBackground,
           zIndex: 100, // Outline might get obstructed by its following siblings
         },
       },
     },
   },
-  MuiButtonBase: {
-    styleOverrides: {
-      root: defaultFocus,
-    },
-    defaultProps: {
-      disableRipple: true,
-    }
-  },
   MuiOutlinedInput: {
     styleOverrides: {
       root: { ...idleOutlineStyle,
-        '&.Mui-focused': defaultFocusStyles,
+        '&.Mui-focused': {
+          backgroundColor: focusBackground,
+          ...defaultFocusOutlineStyles,
+        },
       }
     },    
   },
@@ -77,12 +92,36 @@ export const focusOverrides: Components<Omit<Theme, 'components'>> = {
     styleOverrides: {
       thumb: { ...idleOutlineStyle,
         '&.Mui-focusVisible': {
-          outlineOffset: '6px',
+          outlineOffset: '10px',
           outline: defaultFocusOutlineShorthand,
         },
       },
     },
   },
+  MuiFormControlLabel: {
+    styleOverrides: {
+      label: {
+        '&.Mui-disabled': {
+          color: 'rgba(0, 0, 0, 0.54)',
+        }
+      }
+    }
+  },
+}
+
+export const stepperOverrides: Components<Omit<Theme, 'components'>> = {
+  MuiStepLabel: {
+    styleOverrides: {
+      root: {
+        '& .Mui-disabled circle': {
+          fill: '#e9e9e9',
+        },
+        '& .Mui-disabled text': {
+          fill: 'black',
+        }
+      }
+    }
+  }
 };
 
 /**
@@ -90,7 +129,7 @@ export const focusOverrides: Components<Omit<Theme, 'components'>> = {
  */
 export const defaultSurveyTheme = createTheme(
   {
-    components: { ...buttonOverrides, ...focusOverrides },
+    components: { ...buttonOverrides, ...inputOverrides, ...stepperOverrides },
     palette: {
       primary: {
         main: '#135b9a',

--- a/client/src/themes/survey.ts
+++ b/client/src/themes/survey.ts
@@ -25,15 +25,21 @@ export const buttonOverrides: Components<Omit<Theme, 'components'>> = {
   },
 };
 
+const idleOutlineStyle: CSSInterpolation = {
+  outlineOffset: 0,
+  outlineColor: 'rgba(0,0,0,.0);',
+  transition: 'outline-offset 400ms, outline-color 400ms',
+}
+
+const defaultFocusOutlineShorthand = '2px solid black';
+
 const defaultFocusStyles: CSSInterpolation = {
-  outline: '2px solid black',
+  outline: defaultFocusOutlineShorthand,
   outlineOffset: '2px',
 }
 
 const defaultFocus: CSSInterpolation = {
-  outlineOffset: 0,
-  outlineColor: 'rbga(0,0,0,0)',
-  transition: 'outline-offset 400ms, outline-color   400ms',
+  ...idleOutlineStyle,
   '&.Mui-focusVisible': defaultFocusStyles,
 }
 
@@ -57,7 +63,7 @@ export const focusOverrides: Components<Omit<Theme, 'components'>> = {
   },
   MuiOutlinedInput: {
     styleOverrides: {
-      root: {
+      root: { ...idleOutlineStyle,
         '&.Mui-focused': defaultFocusStyles,
       }
     },    
@@ -69,7 +75,12 @@ export const focusOverrides: Components<Omit<Theme, 'components'>> = {
   },
   MuiSlider: {
     styleOverrides: {
-      thumb: defaultFocus,
+      thumb: { ...idleOutlineStyle,
+        '&.Mui-focusVisible': {
+          outlineOffset: '6px',
+          outline: defaultFocusOutlineShorthand,
+        },
+      },
     },
   },
 };

--- a/client/src/themes/survey.ts
+++ b/client/src/themes/survey.ts
@@ -1,4 +1,4 @@
-import { Theme, Components, createTheme, CSSInterpolation, useTheme } from '@mui/material/styles';
+import { Theme, Components, createTheme, CSSInterpolation } from '@mui/material/styles';
 import { fiFI } from '@mui/material/locale';
 
 const idleOutlineStyle: CSSInterpolation = {
@@ -103,9 +103,9 @@ export const inputOverrides: Components<Omit<Theme, 'components'>> = {
       label: {
         '&.Mui-disabled': {
           color: 'rgba(0, 0, 0, 0.54)',
-        }
-      }
-    }
+        },
+      },
+    },
   },
 }
 

--- a/client/src/themes/survey.ts
+++ b/client/src/themes/survey.ts
@@ -1,4 +1,4 @@
-import { Theme, Components, createTheme } from '@mui/material/styles';
+import { Theme, Components, createTheme, CSSInterpolation } from '@mui/material/styles';
 import { fiFI } from '@mui/material/locale';
 
 export const buttonOverrides: Components<Omit<Theme, 'components'>> = {
@@ -25,12 +25,61 @@ export const buttonOverrides: Components<Omit<Theme, 'components'>> = {
   },
 };
 
+const defaultFocusStyles: CSSInterpolation = {
+  outline: '2px solid black',
+  outlineOffset: '2px',
+}
+
+const defaultFocus: CSSInterpolation = {
+  outlineOffset: 0,
+  outlineColor: 'rbga(0,0,0,0)',
+  transition: 'outline-offset 400ms, outline-color   400ms',
+  '&.Mui-focusVisible': defaultFocusStyles,
+}
+
+export const focusOverrides: Components<Omit<Theme, 'components'>> = {
+  MuiAccordionSummary: {
+    styleOverrides: {
+      root: {
+        '&.Mui-focusVisible': {
+          zIndex: 100, // Outline might get obstructed by its following siblings
+        },
+      },
+    },
+  },
+  MuiButtonBase: {
+    styleOverrides: {
+      root: defaultFocus,
+    },
+    defaultProps: {
+      disableRipple: true,
+    }
+  },
+  MuiOutlinedInput: {
+    styleOverrides: {
+      root: {
+        '&.Mui-focused': defaultFocusStyles,
+      }
+    },    
+  },
+  MuiLink: {
+    styleOverrides: {
+      root: { borderRadius: "2px", ...defaultFocus},
+    },
+  },
+  MuiSlider: {
+    styleOverrides: {
+      thumb: defaultFocus,
+    },
+  },
+};
+
 /**
  * Default theme - used only when survey doesn't have a theme at all set in DB
  */
 export const defaultSurveyTheme = createTheme(
   {
-    components: { ...buttonOverrides },
+    components: { ...buttonOverrides, ...focusOverrides },
     palette: {
       primary: {
         main: '#135b9a',


### PR DESCRIPTION
The default ripple effect of MUI is considered too subtle as focus highlighting.
Replacing with high-contrast, outline-based highlighting style.
Improving contrasts overall.
Closes #94
Closes #93