### PR TITLE
Fix/accessibility and error handling

### DIFF
--- a/client/src/components/CheckBoxQuestion.tsx
+++ b/client/src/components/CheckBoxQuestion.tsx
@@ -77,11 +77,7 @@ export default function CheckBoxQuestion({
           )}
         </>
       )}
-      <FormGroup
-        onBlur={() => {
-          setDirty(true);
-        }}
-      >
+      <FormGroup>
         {question.options.map((option, index) => (
           <FormControlLabel
             key={option.id}

--- a/client/src/components/MapQuestion.tsx
+++ b/client/src/components/MapQuestion.tsx
@@ -61,7 +61,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
         valueRef.current.map((answer, index) => ({
           ...answer,
           geometry: features[index],
-        })),
+        }))
       );
     });
     // On unmount unregister the event handler
@@ -164,15 +164,16 @@ export default function MapQuestion({ value, onChange, question }: Props) {
           () => (answers: SurveyMapSubQuestionAnswer[]) => {
             resolve(answers);
             setSubQuestionDialogOpen(false);
-          },
+          }
         );
-      },
+      }
     );
   }
 
   function getToggleButton(selectionType: MapQuestionSelectionType) {
     return (
       <ToggleButton
+        className="draw-button"
         value={selectionType}
         aria-label={tr.MapQuestion.selectionTypes[selectionType]}
         disabled={!isMapReady}
@@ -264,8 +265,8 @@ export default function MapQuestion({ value, onChange, question }: Props) {
             value.map((answer, index) =>
               index === editingMapAnswer.index
                 ? { ...answer, subQuestionAnswers: answers }
-                : answer,
-            ),
+                : answer
+            )
           );
           stopEditingMapAnswer();
         }}
@@ -285,6 +286,14 @@ export default function MapQuestion({ value, onChange, question }: Props) {
         }}
         onCancel={() => {
           handleSubQuestionDialogClose(null);
+
+          setTimeout(() => {
+            (
+              document.getElementsByClassName(
+                'draw-button'
+              )[0] as HTMLButtonElement
+            )?.focus();
+          }, 1);
         }}
       />
       {/* Confirm dialog for deleting a map answer */}
@@ -294,7 +303,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
         onClose={(result) => {
           if (result) {
             onChange(
-              value.filter((_, index) => index !== editingMapAnswer.index),
+              value.filter((_, index) => index !== editingMapAnswer.index)
             );
             stopEditingMapAnswer();
           }

--- a/client/src/components/MapQuestion.tsx
+++ b/client/src/components/MapQuestion.tsx
@@ -173,7 +173,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
   function getToggleButton(selectionType: MapQuestionSelectionType) {
     return (
       <ToggleButton
-        className="draw-button"
+        id={`${question.id}-draw-button`}
         value={selectionType}
         aria-label={tr.MapQuestion.selectionTypes[selectionType]}
         disabled={!isMapReady}
@@ -283,15 +283,22 @@ export default function MapQuestion({ value, onChange, question }: Props) {
         subQuestions={question.subQuestions}
         onSubmit={(answers) => {
           handleSubQuestionDialogClose(answers);
+          setTimeout(() => {
+            (
+              document.getElementById(
+                `${question.id}-draw-button`
+              ) as HTMLButtonElement
+            )?.focus();
+          }, 1);
         }}
         onCancel={() => {
           handleSubQuestionDialogClose(null);
 
           setTimeout(() => {
             (
-              document.getElementsByClassName(
-                'draw-button'
-              )[0] as HTMLButtonElement
+              document.getElementById(
+                `${question.id}-draw-button`
+              ) as HTMLButtonElement
             )?.focus();
           }, 1);
         }}

--- a/client/src/components/MapSubQuestionDialog.tsx
+++ b/client/src/components/MapSubQuestionDialog.tsx
@@ -128,7 +128,8 @@ export default function MapSubQuestionDialog({
             onBlur={(e: React.FocusEvent<HTMLFieldSetElement>) => {
               if (
                 e.relatedTarget &&
-                !e.currentTarget.contains(e.relatedTarget as Node)
+                !e.currentTarget.contains(e.relatedTarget as Node) &&
+                !infoDialogOpen
               ) {
                 dirty[index] = true;
                 setDirty([...dirty]);

--- a/client/src/components/MapSubQuestionDialog.tsx
+++ b/client/src/components/MapSubQuestionDialog.tsx
@@ -118,15 +118,22 @@ export default function MapSubQuestionDialog({
       aria-label={tr.MapQuestion.subQuestionDialog}
     >
       {title && <DialogTitle>{title}</DialogTitle>}
-      <DialogContent
-        className={classes.content}
-      >
+      <DialogContent className={classes.content}>
         {subQuestions?.map((question, index) => (
           <FormControl
             component="fieldset"
             key={question.id}
             error={dirty?.[index] && validationErrors?.[index].length > 0}
             style={{ width: '100%' }}
+            onBlur={(e: React.FocusEvent<HTMLFieldSetElement>) => {
+              if (
+                e.relatedTarget &&
+                !e.currentTarget.contains(e.relatedTarget as Node)
+              ) {
+                dirty[index] = true;
+                setDirty([...dirty]);
+              }
+            }}
           >
             <FormLabel component="legend">
               {question.title?.[surveyLanguage]} {question.isRequired && '*'}

--- a/client/src/components/MapSubQuestionDialog.tsx
+++ b/client/src/components/MapSubQuestionDialog.tsx
@@ -78,7 +78,7 @@ export default function MapSubQuestionDialog({
     ...(existingAnswer?.subQuestionAnswers ?? []),
   ]);
   const [dirty, setDirty] = useState<boolean[]>([]);
-
+  const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const classes = useStyles();
   const { getValidationErrors } = useSurveyAnswers();
   const { tr, surveyLanguage } = useTranslations();
@@ -135,23 +135,25 @@ export default function MapSubQuestionDialog({
               }
             }}
           >
-            <FormLabel component="legend">
-              {question.title?.[surveyLanguage]} {question.isRequired && '*'}
-            </FormLabel>
-            <div
+            <FormLabel
+              component="legend"
               style={{
                 display: 'flex',
                 flexDirection: 'row',
                 alignItems: 'center',
               }}
             >
+              {question.title?.[surveyLanguage]} {question.isRequired && '*'}
               {question.info && question.info?.[surveyLanguage] && (
                 <SectionInfo
+                  infoDialogOpen={infoDialogOpen}
+                  setInfoDialogOpen={setInfoDialogOpen}
                   infoText={question.info?.[surveyLanguage]}
                   subject={question.title?.[surveyLanguage]}
                 />
               )}
-            </div>
+            </FormLabel>
+
             {question.type === 'checkbox' ? (
               <CheckBoxQuestion
                 autoFocus={index === 0}

--- a/client/src/components/RadioQuestion.tsx
+++ b/client/src/components/RadioQuestion.tsx
@@ -48,8 +48,10 @@ export default function RadioQuestion({
         id={`${question.id}-input`}
         value={value}
         onChange={(event) => {
-          setDirty(true);
           const numericValue = Number(event.currentTarget.value);
+          if (event.currentTarget.value.length > 0 && !isNaN(numericValue)) {
+            setDirty(true);
+          }
           // Empty strings are converted to 0 with Number()
           onChange(
             event.currentTarget.value.length > 0 && !isNaN(numericValue)

--- a/client/src/components/SectionInfo.tsx
+++ b/client/src/components/SectionInfo.tsx
@@ -52,6 +52,7 @@ export default function SectionInfo({
         </DialogContent>
         <DialogActions>
           <Button
+            className="close-section-info-button"
             autoFocus
             color="primary"
             variant="contained"

--- a/client/src/components/SectionInfo.tsx
+++ b/client/src/components/SectionInfo.tsx
@@ -18,6 +18,8 @@ interface Props {
   infoText: string;
   style?: React.CSSProperties;
   hiddenFromScreenReader?: boolean;
+  infoDialogOpen: boolean;
+  setInfoDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function SectionInfo({
@@ -25,8 +27,9 @@ export default function SectionInfo({
   infoText,
   style,
   hiddenFromScreenReader = false,
+  infoDialogOpen,
+  setInfoDialogOpen,
 }: Props) {
-  const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const { tr } = useTranslations();
   const dialogId = useId();
 

--- a/client/src/components/SurveyQuestion.tsx
+++ b/client/src/components/SurveyQuestion.tsx
@@ -30,6 +30,7 @@ function SurveyQuestion({ question, pageUnfinished }: Props) {
     useSurveyAnswers();
   const { tr, surveyLanguage } = useTranslations();
   const [dirty, setDirty] = useState(false);
+  const [infoDialogOpen, setInfoDialogOpen] = useState(false);
 
   const value = useMemo(
     () => answers.find((answer) => answer.sectionId === question.id)?.value,
@@ -53,9 +54,7 @@ function SurveyQuestion({ question, pageUnfinished }: Props) {
         if (
           e.relatedTarget &&
           !e.currentTarget.contains(e.relatedTarget as Node) &&
-          !(e.relatedTarget as HTMLElement)?.classList.contains(
-            'close-section-info-button'
-          )
+          !infoDialogOpen
         ) {
           setDirty(true);
         }
@@ -95,6 +94,8 @@ function SurveyQuestion({ question, pageUnfinished }: Props) {
         )}
         {question.info && question.info?.[surveyLanguage] && (
           <SectionInfo
+            infoDialogOpen={infoDialogOpen}
+            setInfoDialogOpen={setInfoDialogOpen}
             hiddenFromScreenReader={false}
             infoText={question.info?.[surveyLanguage]}
             subject={question.title?.[surveyLanguage]}

--- a/client/src/components/SurveyQuestion.tsx
+++ b/client/src/components/SurveyQuestion.tsx
@@ -33,12 +33,12 @@ function SurveyQuestion({ question, pageUnfinished }: Props) {
 
   const value = useMemo(
     () => answers.find((answer) => answer.sectionId === question.id)?.value,
-    [answers, question],
+    [answers, question]
   );
 
   const validationErrors = useMemo(
     () => (dirty || pageUnfinished ? getValidationErrors(question) : []),
-    [dirty, question, value, pageUnfinished],
+    [dirty, question, value, pageUnfinished]
   );
 
   return (
@@ -52,7 +52,10 @@ function SurveyQuestion({ question, pageUnfinished }: Props) {
       onBlur={(e: React.FocusEvent<HTMLFieldSetElement>) => {
         if (
           e.relatedTarget &&
-          !e.currentTarget.contains(e.relatedTarget as Node)
+          !e.currentTarget.contains(e.relatedTarget as Node) &&
+          !(e.relatedTarget as HTMLElement)?.classList.contains(
+            'close-section-info-button'
+          )
         ) {
           setDirty(true);
         }


### PR DESCRIPTION
- In map subquestion dialog errors are now displayed when leaving focus
- After closing map subquestion dialog focus is moved back to the respective question 
- Input is not validated unnecessarily when 
  - Section info is opened
  - Text field for radio question appears