### PR TITLE
Encode and decode File-details to allow special characters

### DIFF
--- a/client/src/components/SurveyLandingPage.tsx
+++ b/client/src/components/SurveyLandingPage.tsx
@@ -81,7 +81,7 @@ interface Props {
   isTestSurvey: boolean;
   continueUnfinished: boolean;
   onStart: () => void;
-  surveyBackgroundImage?: { attributions: string };
+  surveyBackgroundImage?: { attributions?: string };
 }
 
 export default function SurveyLandingPage({

--- a/client/src/components/SurveyPage.tsx
+++ b/client/src/components/SurveyPage.tsx
@@ -15,6 +15,7 @@ import SurveyStepper from './SurveyStepper';
 import SurveyThanksPage from './SurveyThanksPage';
 import TestSurveyFrame from './TestSurveyFrame';
 import { UnavailableSurvey } from './UnavailableSurvey';
+import { getFileDetails } from '@src/controllers/FileController';
 
 interface Props {
   isTestSurvey?: boolean;
@@ -25,7 +26,7 @@ export default function SurveyPage({ isTestSurvey }: Props) {
   const [showLandingPage, setShowLandingPage] = useState(true);
   const [showThanksPage, setShowThanksPage] = useState(false);
   const [surveyBackgroundImage, setSurveyBackgroundImage] = useState<{
-    attributions: string;
+    attributions?: string;
   }>(null);
   const [errorStatusCode, setErrorStatusCode] = useState<number>(null);
   const [continueUnfinished, setContinueUnfinished] = useState(false);
@@ -58,10 +59,7 @@ export default function SurveyPage({ isTestSurvey }: Props) {
             survey.backgroundImagePath,
             survey.backgroundImageName,
           );
-          const response = await fetch(`/api/file/${fullFilePath}`);
-          const details = JSON.parse(
-            response.headers.get('File-details') ?? '{}',
-          );
+          const details = await getFileDetails(fullFilePath);
           setSurveyBackgroundImage(details);
         }
         setSurvey(survey);

--- a/client/src/components/SurveyThanksPage.tsx
+++ b/client/src/components/SurveyThanksPage.tsx
@@ -13,6 +13,7 @@ import React, { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeExternalLinks from 'rehype-external-links';
 import Footer from './Footer';
+import { getFileDetails } from '@src/controllers/FileController';
 
 type StyleKeys = 'testSurveyHeader';
 
@@ -37,12 +38,9 @@ export default function SurveyThanksPage({ survey, isTestSurvey }: Props) {
 
   useEffect(() => {
     async function getImageHeaders() {
-      const res = await fetch(
-        `api/file/${survey.thanksPage.imagePath[0]}/${survey.thanksPage.imageName}`,
-        { method: 'HEAD' },
+      const details = await getFileDetails(
+        `${survey.thanksPage.imagePath[0]}/${survey.thanksPage.imageName}`,
       );
-
-      const details = JSON.parse(res.headers.get('File-details'));
 
       setImageAltText(details?.imageAltText);
     }

--- a/client/src/components/admin/EditSurveyInfo.tsx
+++ b/client/src/components/admin/EditSurveyInfo.tsx
@@ -14,10 +14,7 @@ import {
 import { makeStyles } from '@mui/styles';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import {
-  DateTimePicker,
-  DateTimePickerToolbarProps,
-} from '@mui/x-date-pickers/DateTimePicker';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { useSurvey } from '@src/stores/SurveyContext';
 import { useToasts } from '@src/stores/ToastContext';
 import { useTranslations } from '@src/stores/TranslationContext';
@@ -75,7 +72,7 @@ export default function EditSurveyInfo() {
       setUsersLoading(true);
       try {
         const users = await fetch('/api/users/others').then(
-          (response) => response.json() as Promise<User[]>
+          (response) => response.json() as Promise<User[]>,
         );
         setUsers(users);
       } catch (error) {

--- a/client/src/controllers/AdminFileController.ts
+++ b/client/src/controllers/AdminFileController.ts
@@ -1,8 +1,11 @@
+import { decodeFileDetailValues } from '@src/utils/request';
+
 const apiURL = '/api/file/instructions';
 
 export async function getInstructionFilename() {
   const response = await fetch(apiURL, { method: 'HEAD' });
-  return JSON.parse(response.headers.get('File-details')).name;
+  const details = JSON.parse(response.headers.get('File-details'));
+  return decodeFileDetailValues(details)?.name;
 }
 
 export async function storeAdminInstructions(file: File) {

--- a/client/src/controllers/FileController.ts
+++ b/client/src/controllers/FileController.ts
@@ -1,0 +1,9 @@
+import { FileDetails } from '@interfaces/survey';
+import { decodeFileDetailValues } from '@src/utils/request';
+
+export async function getFileDetails(filePath: string): Promise<FileDetails> {
+  const response = await fetch(`/api/file/${filePath}`, { method: 'HEAD' });
+  const details = JSON.parse(response.headers.get('File-details') ?? '{}');
+
+  return decodeFileDetailValues(details);
+}

--- a/client/src/utils/request.ts
+++ b/client/src/utils/request.ts
@@ -1,3 +1,5 @@
+import { FileDetails } from '@interfaces/survey';
+
 /**
  * Fetch TS typings only allow string values in body -
  * override it with unknown value (JSON serialization is done in the wrapper anyway)
@@ -29,6 +31,19 @@ function serializeBody(body: unknown): {
 }
 
 /**
+ * Decode UTF-8 encoded strings from response headers
+ */
+
+export function decodeFileDetailValues(obj: FileDetails): FileDetails {
+  return Object.keys(obj).reduce((object, key: keyof FileDetails) => {
+    return {
+      ...object,
+      [key]: decodeURIComponent(obj[key]),
+    };
+  }, {});
+}
+
+/**
  * Request wrapper for handling JSON data.
  * Accepts unknown values for the request body.
  * Body is serialized as JSON, unless it is of type ArrayBuffer - in this case the data is sent as is.
@@ -38,7 +53,7 @@ function serializeBody(body: unknown): {
  */
 export async function request<Response = unknown>(
   url: string,
-  options?: RequestOptions
+  options?: RequestOptions,
 ) {
   const body = options?.body ? serializeBody(options.body) : undefined;
   const response = await fetch(url, {

--- a/interfaces/survey.d.ts
+++ b/interfaces/survey.d.ts
@@ -665,3 +665,9 @@ export interface SurveyEmailInfoItem {
 }
 
 export type ImageType = 'backgroundImage' | 'thanksPageImage';
+
+export interface FileDetails {
+  attributions?: string;
+  imageAltText?: string;
+  name?: string;
+}

--- a/server/src/routes/file.routes.ts
+++ b/server/src/routes/file.routes.ts
@@ -9,7 +9,11 @@ import {
   storeFile,
 } from '@src/application/survey';
 import { ensureAuthenticated } from '@src/auth';
-import { parseMimeType, validateRequest } from '@src/utils';
+import {
+  encodeFileDetailValues,
+  parseMimeType,
+  validateRequest,
+} from '@src/utils';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { param } from 'express-validator';
@@ -29,9 +33,12 @@ router.get(
     const row = await getAdminInstructions();
 
     res.set('Content-type', row.mimeType);
-    res.set('File-details', JSON.stringify({ name: row.name }));
+    res.set(
+      'File-details',
+      JSON.stringify(encodeFileDetailValues({ name: row.name })),
+    );
     res.status(200).send(row.data);
-  })
+  }),
 );
 
 /**
@@ -47,11 +54,11 @@ router.post(
     const { name } = await storeAdminInstructions(
       originalname,
       parseMimeType(mimetype),
-      buffer
+      buffer,
     );
 
     res.status(200).json({ message: `File ${name} succesfully stored` });
-  })
+  }),
 );
 
 /**
@@ -83,7 +90,7 @@ router.post(
       surveyId: surveyId == null ? null : Number(surveyId),
     });
     res.status(200).json({ id });
-  })
+  }),
 );
 
 /**
@@ -98,7 +105,7 @@ router.get(
     const row = await getImages(filePathArray);
 
     res.status(200).json(row);
-  })
+  }),
 );
 
 /**
@@ -118,9 +125,12 @@ router.get(
     const filePathArray = filePath?.split('/') ?? [];
     const row = await getFile(fileName, filePathArray);
     res.set('Content-type', row.mimeType);
-    res.set('File-details', JSON.stringify(row.details));
+    res.set(
+      'File-details',
+      JSON.stringify(encodeFileDetailValues(row.details)),
+    );
     res.status(200).send(row.data);
-  })
+  }),
 );
 
 /**
@@ -142,7 +152,7 @@ router.delete(
 
     await removeFile(fileName, filePathArray);
     res.status(200).send();
-  })
+  }),
 );
 
 export default router;

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { ValidationChain, validationResult } from 'express-validator';
 import { BadRequestError } from './error';
-import { ImageType } from '@interfaces/survey';
+import { FileDetails, ImageType } from '@interfaces/survey';
 import { MimeType } from '@interfaces/admin';
 
 /**
@@ -38,6 +38,19 @@ export function base64Encode(str: string) {
  */
 export function base64Decode(str: string) {
   return Buffer.from(str, 'base64').toString('ascii');
+}
+
+/**
+ * Encode ASCII strings to UTF-8 from response headers
+ */
+
+export function encodeFileDetailValues(obj: FileDetails): FileDetails {
+  return Object.keys(obj).reduce((object, key: keyof FileDetails) => {
+    return {
+      ...object,
+      [key]: encodeURIComponent(obj[key]),
+    };
+  }, {});
 }
 
 function isString(text: unknown): text is string {


### PR DESCRIPTION
Fixes following bugs
- Landing page/ thankspage image would not show if altText or attributions included special characters
- Current instructions in instructions dialog would not be displayed if the filename included special characters