### PR TITLE
Fixing test findings

### DIFF
--- a/client/src/components/CheckBoxQuestion.tsx
+++ b/client/src/components/CheckBoxQuestion.tsx
@@ -8,7 +8,7 @@ import {
 } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import { useTranslations } from '@src/stores/TranslationContext';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { createRef, useEffect, useMemo, useRef, useState } from 'react';
 
 /**
  * Max length of a custom answer in radio/checkbox questions
@@ -34,6 +34,18 @@ export default function CheckBoxQuestion({
 }: Props) {
   const [customAnswerValue, setCustomAnswerValue] = useState('');
   const { tr, surveyLanguage } = useTranslations();
+  const actionRef = useRef([]);
+
+  if (autoFocus) {
+    actionRef.current = question.options.map(
+      (_, i) => actionRef.current[i] ?? createRef(),
+    );
+  }
+
+  useEffect(() => {
+    // autoFocus prop won't trigger focus styling, must be done manually
+    autoFocus && actionRef.current[0]?.current.focusVisible();
+  }, []);
 
   const answerLimitText = useMemo(() => {
     if (!question.answerLimits) {
@@ -84,6 +96,7 @@ export default function CheckBoxQuestion({
             label={option.text?.[surveyLanguage] ?? ''}
             control={
               <Checkbox
+                action={actionRef.current[index]}
                 autoFocus={index === 0 && autoFocus}
                 // TS can't infer the precise memoized value type from question.type, but for checkboxes it's always an array
                 checked={value.includes(option.id)}
@@ -144,8 +157,8 @@ export default function CheckBoxQuestion({
                 value.map((option) =>
                   typeof option === 'string'
                     ? event.currentTarget.value
-                    : option
-                )
+                    : option,
+                ),
               );
             }}
           />

--- a/client/src/components/MapQuestion.tsx
+++ b/client/src/components/MapQuestion.tsx
@@ -11,6 +11,7 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
 import { useSurveyMap } from '@src/stores/SurveyMapContext';
 import { useTranslations } from '@src/stores/TranslationContext';
@@ -152,6 +153,8 @@ export default function MapQuestion({ value, onChange, question }: Props) {
     }
   }, [drawing]);
 
+  const mobileWidth = useMediaQuery('(max-width:600px)');
+
   async function getSubQuestionAnswers() {
     // Don't open the dialog at all if there are no subquestions
     if (!question.subQuestions?.length) {
@@ -229,6 +232,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
             setSelectionType(newValue);
           }}
           aria-label={tr.MapQuestion.mapSelectionButtons}
+          orientation={mobileWidth ? 'vertical' : 'horizontal'}
         >
           {question.selectionTypes.includes('point') &&
             getToggleButton('point')}

--- a/client/src/components/MapQuestion.tsx
+++ b/client/src/components/MapQuestion.tsx
@@ -61,7 +61,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
         valueRef.current.map((answer, index) => ({
           ...answer,
           geometry: features[index],
-        }))
+        })),
       );
     });
     // On unmount unregister the event handler
@@ -164,15 +164,15 @@ export default function MapQuestion({ value, onChange, question }: Props) {
           () => (answers: SurveyMapSubQuestionAnswer[]) => {
             resolve(answers);
             setSubQuestionDialogOpen(false);
-          }
+          },
         );
-      }
+      },
     );
   }
 
   function getToggleButton(selectionType: MapQuestionSelectionType) {
     const markingCount = value?.filter(
-      (answer) => answer.selectionType === selectionType
+      (answer) => answer.selectionType === selectionType,
     ).length;
     return (
       <ToggleButton
@@ -190,21 +190,21 @@ export default function MapQuestion({ value, onChange, question }: Props) {
           {selectionType === 'point' && (
             <img
               style={{ height: '2rem' }}
-              src={`api/feature-styles/icons/point_icon`}
+              src={`/api/feature-styles/icons/point_icon`}
               alt=""
             />
           )}
           {selectionType === 'line' && (
             <img
               style={{ height: '2rem' }}
-              src={`api/feature-styles/icons/line_icon`}
+              src={`/api/feature-styles/icons/line_icon`}
               alt=""
             />
           )}
           {selectionType === 'area' && (
             <img
               style={{ height: '2rem' }}
-              src={`api/feature-styles/icons/area_icon`}
+              src={`/api/feature-styles/icons/area_icon`}
               alt=""
             />
           )}
@@ -267,8 +267,8 @@ export default function MapQuestion({ value, onChange, question }: Props) {
             value.map((answer, index) =>
               index === editingMapAnswer.index
                 ? { ...answer, subQuestionAnswers: answers }
-                : answer
-            )
+                : answer,
+            ),
           );
           stopEditingMapAnswer();
         }}
@@ -288,7 +288,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
           setTimeout(() => {
             (
               document.getElementById(
-                `${question.id}-draw-button`
+                `${question.id}-draw-button`,
               ) as HTMLButtonElement
             )?.focus();
           }, 1);
@@ -299,7 +299,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
           setTimeout(() => {
             (
               document.getElementById(
-                `${question.id}-draw-button`
+                `${question.id}-draw-button`,
               ) as HTMLButtonElement
             )?.focus();
           }, 1);
@@ -313,7 +313,7 @@ export default function MapQuestion({ value, onChange, question }: Props) {
         onClose={(result) => {
           if (result) {
             onChange(
-              value.filter((_, index) => index !== editingMapAnswer.index)
+              value.filter((_, index) => index !== editingMapAnswer.index),
             );
             stopEditingMapAnswer();
           }

--- a/client/src/components/MatrixQuestion.tsx
+++ b/client/src/components/MatrixQuestion.tsx
@@ -131,7 +131,7 @@ export default function MatrixQuestion({
   function handleChange(
     subjectIndex: number,
     event: React.ChangeEvent<HTMLInputElement> | SelectChangeEvent,
-    type: 'radio' | 'select' = 'radio'
+    type: 'radio' | 'select' = 'radio',
   ) {
     // Ignore if the value is false
     if (type === 'radio' && !(event.target as HTMLInputElement).checked) {
@@ -146,16 +146,21 @@ export default function MatrixQuestion({
 
   return (
     <>
-      {!componentState.isOverflow && (
+      {!isMobileWidth && !componentState.isOverflow && (
         <TableContainer id={`${question.id}-input`} ref={radioRef}>
           <Table size="small">
-            {question.title && <caption style={visuallyHidden}>{question.title?.[surveyLanguage]}</caption>}
+            {question.title && (
+              <caption style={visuallyHidden}>
+                {question.title?.[surveyLanguage]}
+              </caption>
+            )}
             <TableHead>
               <TableRow>
                 <TableCell scope="col" className={classes.stickyLeft} />
                 {question.classes.map((entry, index) => {
                   return (
-                    <TableCell scope="col"
+                    <TableCell
+                      scope="col"
                       key={index}
                       className={`${classes.matrixCell} ${classes.matrixText}`}
                     >
@@ -164,7 +169,8 @@ export default function MatrixQuestion({
                   );
                 })}
                 {question.allowEmptyAnswer && (
-                  <TableCell scope="col"
+                  <TableCell
+                    scope="col"
                     className={`${classes.matrixCell} ${classes.matrixText}`}
                   >
                     {tr.MatrixQuestion.emptyAnswer}
@@ -230,23 +236,28 @@ export default function MatrixQuestion({
           sx={{ marginTop: 2 }}
         >
           <Table size="small">
-            {question.title && <caption style={visuallyHidden}>{question.title?.[surveyLanguage]}</caption>}
+            {question.title && (
+              <caption style={visuallyHidden}>
+                {question.title?.[surveyLanguage]}
+              </caption>
+            )}
             <TableHead>
               <TableRow>
-                <TableCell scope="col"
+                <TableCell
+                  scope="col"
                   className={[
                     classes.stickyLeft,
                     classes.matrixCell,
                     classes.matrixText,
-                  ].join(' ')}>
+                  ].join(' ')}
+                >
                   {tr.MatrixQuestion.subject}
                 </TableCell>
-                <TableCell scope="col"
-                  className={[
-                    classes.matrixCell,
-                    classes.matrixText,
-                  ].join(' ')}
-                  sx={{"&&": {textAlign: "left"}}}>
+                <TableCell
+                  scope="col"
+                  className={[classes.matrixCell, classes.matrixText].join(' ')}
+                  sx={{ '&&': { textAlign: 'left' } }}
+                >
                   {tr.MatrixQuestion.response}
                 </TableCell>
               </TableRow>

--- a/client/src/components/RadioQuestion.tsx
+++ b/client/src/components/RadioQuestion.tsx
@@ -2,7 +2,7 @@ import { SurveyRadioQuestion } from '@interfaces/survey';
 import { FormControlLabel, Radio, RadioGroup, TextField } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { useTranslations } from '@src/stores/TranslationContext';
-import React, { useEffect, useState } from 'react';
+import React, { createRef, useEffect, useRef, useState } from 'react';
 
 const useStyles = makeStyles({
   labelStyles: {
@@ -35,6 +35,18 @@ export default function RadioQuestion({
   const [customAnswerValue, setCustomAnswerValue] = useState('');
   const { tr, surveyLanguage } = useTranslations();
   const classes = useStyles();
+  const actionRef = useRef([]);
+
+  if (autoFocus) {
+    actionRef.current = question.options.map(
+      (_, i) => actionRef.current[i] ?? createRef(),
+    );
+  }
+
+  useEffect(() => {
+    // autoFocus prop won't trigger focus styling, must be done manually
+    autoFocus && actionRef.current[0]?.current.focusVisible();
+  }, []);
 
   // Update custom answer value if value from context is string
   useEffect(() => {
@@ -56,7 +68,7 @@ export default function RadioQuestion({
           onChange(
             event.currentTarget.value.length > 0 && !isNaN(numericValue)
               ? numericValue
-              : event.currentTarget.value
+              : event.currentTarget.value,
           );
         }}
         name={`${question.title?.[surveyLanguage]}-group`}
@@ -66,7 +78,12 @@ export default function RadioQuestion({
             key={option.id}
             value={option.id}
             label={option.text?.[surveyLanguage] ?? ''}
-            control={<Radio autoFocus={index === 0 && autoFocus} />}
+            control={
+              <Radio
+                action={actionRef.current[index]}
+                autoFocus={index === 0 && autoFocus}
+              />
+            }
             classes={{ label: classes.labelStyles }}
           />
         ))}

--- a/client/src/components/admin/EditSurveyHeader.tsx
+++ b/client/src/components/admin/EditSurveyHeader.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import LanguageMenu from '../LanguageMenu';
 import SurveyLanguageMenu from '../SurveyLanguageMenu';
 import AppBarUserMenu from './AppBarUserMenu';
+import { AdminInstructionButton } from './AdminInstructionButton';
 
 interface Props {
   sideBarWidth: number;
@@ -51,6 +52,7 @@ export default function EditSurveyHeader(props: Props) {
         >
           {originalActiveSurvey.localisationEnabled && <SurveyLanguageMenu />}
           <LanguageMenu />
+          <AdminInstructionButton />
           <AppBarUserMenu />
         </div>
       </Toolbar>

--- a/client/src/stores/en.json
+++ b/client/src/stores/en.json
@@ -502,7 +502,7 @@
   },
   "FooterLinks": {
     "accessibility": "Accessibility report",
-    "privacyStatement": "Data protection and management"
+    "privacyStatement": "Data protection statement"
   },
   "IconAltTexts": {
     "treBannerAltText": "Tampere banner",

--- a/client/src/stores/fi.json
+++ b/client/src/stores/fi.json
@@ -503,7 +503,7 @@
   },
   "FooterLinks": {
     "accessibility": "Saavutettavuusseloste",
-    "privacyStatement": "Tietosuoja ja tiedonhallinta"
+    "privacyStatement": "Tietosuojaseloste"
   },
   "IconAltTexts": {
     "treBannerAltText": "Tampereen vaakunalogo",


### PR DESCRIPTION
- Data protection link text was incorrect
- Map marking icons in test surveys were broken
- Ensure only one matrix question layout renders at a time
- Map question button group assumes a vertical layout on mobile in order to avoid horizontal scrolling
- Trigger autofocus visual styling in radio buttons and checkboxes in map subquestion dialogs
Closes #165 