### PR TITLE
Remove validation when pressing cancel button in mapsubquestion dialog

### DIFF
--- a/client/src/components/MapSubQuestionDialog.tsx
+++ b/client/src/components/MapSubQuestionDialog.tsx
@@ -128,7 +128,11 @@ export default function MapSubQuestionDialog({
             onBlur={(e: React.FocusEvent<HTMLFieldSetElement>) => {
               if (
                 e.relatedTarget &&
+                !(e.relatedTarget as HTMLButtonElement).classList.contains(
+                  'cancel-button',
+                ) &&
                 !e.currentTarget.contains(e.relatedTarget as Node) &&
+                open &&
                 !infoDialogOpen
               ) {
                 dirty[index] = true;
@@ -236,6 +240,7 @@ export default function MapSubQuestionDialog({
         )}
         <div style={{ flexGrow: 1 }} />
         <Button
+          className="cancel-button"
           variant="outlined"
           onClick={() => {
             onCancel();


### PR DESCRIPTION
- Validation is not triggered when exiting map sub-question dialog using cancel button
- Validation is also not triggered when sub-question dialog closes 

Closes #183 