### PR TITLE
Fix/bug fixes

### DIFF
--- a/client/src/components/SurveyMap.tsx
+++ b/client/src/components/SurveyMap.tsx
@@ -5,18 +5,21 @@ import { useTranslations } from '@src/stores/TranslationContext';
 import { visuallyHidden } from '@mui/utils';
 import OskariRPC from 'oskari-rpc';
 import React, { useEffect, useRef, useState } from 'react';
+import { channel } from 'diagnostics_channel';
 
 interface Props {
   url: string;
   layers: number[];
   onAnswer?: () => void;
   defaultMapView?: GeoJSON.FeatureCollection;
+  pageId: number;
 }
 
 export default function SurveyMap(props: Props) {
   const [mapInitialized, setMapInitialized] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>();
   const {
+    rpcChannel,
     setRpcChannel,
     isMapReady,
     initializeMap,
@@ -72,13 +75,16 @@ export default function SurveyMap(props: Props) {
   }, [isMapReady]);
 
   useEffect(() => {
-    if (mapInitialized && props.defaultMapView) {
+    if (!mapInitialized) return;
+    if (props.defaultMapView) {
       centerToDefaultView(props.defaultMapView, {
         fill: { color: '#00000000' },
         stroke: { color: '#00000000' },
       });
+    } else {
+      rpcChannel.resetState(() => {});
     }
-  }, [props.defaultMapView, mapInitialized]);
+  }, [props.defaultMapView, mapInitialized, props.pageId]);
 
   return (
     props.url && (

--- a/client/src/components/SurveyMap.tsx
+++ b/client/src/components/SurveyMap.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from '@src/stores/TranslationContext';
 import { visuallyHidden } from '@mui/utils';
 import OskariRPC from 'oskari-rpc';
 import React, { useEffect, useRef, useState } from 'react';
-import { channel } from 'diagnostics_channel';
 
 interface Props {
   url: string;

--- a/client/src/components/SurveyStepper.tsx
+++ b/client/src/components/SurveyStepper.tsx
@@ -587,6 +587,7 @@ export default function SurveyStepper({
       case 'map':
         return (
           <SurveyMap
+            pageId={currentPage.id}
             defaultMapView={currentPage.sidebar?.defaultMapView}
             url={survey.mapUrl}
             layers={currentPage.sidebar.mapLayers}

--- a/client/src/components/admin/EditSurveySideBar.tsx
+++ b/client/src/components/admin/EditSurveySideBar.tsx
@@ -176,12 +176,18 @@ export default function EditSurveySideBar(props: Props) {
                               localStorage.setItem(
                                 'clipboard-content',
                                 JSON.stringify({
-                                  clipboardPage: copiedSurveyPage,
+                                  clipboardPage: {
+                                    ...copiedSurveyPage,
+                                    conditions: {},
+                                  },
                                   clipboardSection,
                                 }),
                               );
                               // Store page to context for the currently active browser tab to get access to it
-                              setClipboardPage(copiedSurveyPage);
+                              setClipboardPage({
+                                ...copiedSurveyPage,
+                                conditions: {},
+                              });
                               showToast({
                                 message: tr.EditSurvey.pageCopied,
                                 severity: 'success',

--- a/client/src/components/admin/SurveySectionAccordion/FollowUpSectionAccordion.tsx
+++ b/client/src/components/admin/SurveySectionAccordion/FollowUpSectionAccordion.tsx
@@ -26,7 +26,6 @@ import {
 import {
   DragIndicator,
   ExpandMore,
-  ContentCopy,
   Article,
   AttachFile,
   CheckBox,
@@ -360,9 +359,7 @@ export function FollowUpSectionAccordion(props: Props) {
                 severity: 'success',
               });
             }}
-          >
-            <ContentCopy />
-          </IconButton>
+          ></IconButton>
           <div {...props.provided.dragHandleProps} style={{ display: 'flex' }}>
             <DragIndicator />
           </div>

--- a/client/src/typings/oskari-rpc.d.ts
+++ b/client/src/typings/oskari-rpc.d.ts
@@ -296,6 +296,7 @@ declare module 'oskari-rpc' {
     getSupportedRequests: (callback: (requests: unknown[]) => void) => void;
     getSupportedFunctions: (callback: (functions: unknown[]) => void) => void;
     getInfo: (callback: (info: any) => void) => void;
+    resetState: (callback: (data: any) => void) => void;
     /**
      * Post an Oskari request
      */


### PR DESCRIPTION
- Fix several errors while reordering conditional pages.
- The copy button is completely removed from the conditional section rows.
- If no boundaries are defined on the map, set the boundary explicitly to the default view of the map publication.
- If a conditional page is copied, remove references to conditionality from the page's JSON data structure during the copying process.