### PR TITLE
Block survey routes from non-authors

### DIFF
--- a/client/src/components/admin/EditSurveyPage.tsx
+++ b/client/src/components/admin/EditSurveyPage.tsx
@@ -1,22 +1,24 @@
+import { SurveyPageSidebarImageSize } from '@interfaces/survey';
+import { CheckSharp, ClearSharp } from '@mui/icons-material';
 import {
+  Box,
   Button,
   Checkbox,
+  FormControl,
   FormControlLabel,
   FormGroup,
   FormLabel,
+  Radio,
+  RadioGroup,
   Skeleton,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
-  FormControl,
-  Radio,
-  RadioGroup,
-  Box,
   Typography,
 } from '@mui/material';
-import { ClearSharp, CheckSharp } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import { useSurvey } from '@src/stores/SurveyContext';
+import { useAdminMap } from '@src/stores/SurveyMapContext';
 import { useToasts } from '@src/stores/ToastContext';
 import { useTranslations } from '@src/stores/TranslationContext';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -24,12 +26,10 @@ import { useHistory, useParams } from 'react-router-dom';
 import ConfirmDialog from '../ConfirmDialog';
 import Fieldset from '../Fieldset';
 import AddSurveySectionActions from './AddSurveySectionActions';
+import { AdminSurveyMapPreview } from './AdminSurveyMapPreview';
+import { EditSurveyPageConditions } from './EditSurveyPageConditions';
 import FileUpload from './FileUpload';
 import SurveySections from './SurveySections';
-import { SurveyPageSidebarImageSize } from '@interfaces/survey';
-import { EditSurveyPageConditions } from './EditSurveyPageConditions';
-import { AdminSurveyMapPreview } from './AdminSurveyMapPreview';
-import { useAdminMap } from '@src/stores/SurveyMapContext';
 
 
 const useStyles = makeStyles({
@@ -389,7 +389,7 @@ export default function EditSurveyPage() {
           if (result) {
             setLoading(true);
             try {
-              await deletePage(page.id);
+              await deletePage(activeSurvey.id, page.id);
             } catch (error) {
               showToast({
                 severity: 'error',

--- a/client/src/stores/SurveyContext.tsx
+++ b/client/src/stores/SurveyContext.tsx
@@ -9,8 +9,8 @@ import { getSurvey, updateSurvey } from '@src/controllers/SurveyController';
 import { request } from '@src/utils/request';
 import { useDebounce } from '@src/utils/useDebounce';
 import React, {
-  createContext,
   ReactNode,
+  createContext,
   useContext,
   useEffect,
   useMemo,
@@ -289,12 +289,12 @@ export function useSurvey() {
      * Deletes page with given ID.
      * @param pageId Page ID
      */
-    async deletePage(pageId: number) {
+    async deletePage(surveyId: number, pageId: number) {
       dispatch({
         type: 'START_LOADING_ACTIVE_SURVEY',
       });
       try {
-        await request(`/api/surveys/page/${pageId}`, { method: 'DELETE' });
+        await request(`/api/surveys/${surveyId}/page/${pageId}`, { method: 'DELETE' });
         dispatch({ type: 'DELETE_PAGE', pageId });
         dispatch({
           type: 'STOP_LOADING_ACTIVE_SURVEY',

--- a/server/src/routes/survey.routes.ts
+++ b/server/src/routes/survey.routes.ts
@@ -326,12 +326,12 @@ router.post(
   ]),
   asyncHandler(async (req, res) => {
     const surveyId = Number(req.params.id);
-    const permissionsOk = await userCanEditSurvey(req.user, id);
+    const permissionsOk = await userCanEditSurvey(req.user, surveyId);
     if (!permissionsOk) {
       throw new ForbiddenError('User not author nor admin of the survey');
     }
     const partialPage = req.body as Partial<SurveyPage>;
-    const createdSurveyPage = await createSurveyPage(id, partialPage);
+    const createdSurveyPage = await createSurveyPage(surveyId, partialPage);
     res.status(201).json(createdSurveyPage);
   }),
 );
@@ -340,19 +340,23 @@ router.post(
  * Endpoint for deleting an existing survey page
  */
 router.delete(
-  '/page/:id',
+  '/:surveyId/page/:id',
   ensureAuthenticated(),
+  validateRequest([
+    param('surveyId').isNumeric().toInt().withMessage('surveyId must be a number'),
+  ]),
   validateRequest([
     param('id').isNumeric().toInt().withMessage('ID must be a number'),
   ]),
   asyncHandler(async (req, res) => {
-    const surveyId = Number(req.params.id);
+    const pageId = Number(req.params.id);
+    const surveyId = Number(req.params.surveyId);
     const permissionsOk = await userCanEditSurvey(req.user, surveyId);
     if (!permissionsOk) {
       throw new ForbiddenError('User not author nor admin of the survey');
     }
 
-    const deletedSurveyPage = await deleteSurveyPage(id);
+    const deletedSurveyPage = await deleteSurveyPage(pageId);
     res.status(200).json(deletedSurveyPage);
   }),
 );

--- a/server/src/routes/survey.routes.ts
+++ b/server/src/routes/survey.routes.ts
@@ -284,6 +284,11 @@ router.post(
   ]),
   asyncHandler(async (req, res) => {
     const surveyId = Number(req.params.id);
+    const permissionsOk = await userCanEditSurvey(req.user, surveyId);
+    if (!permissionsOk) {
+      throw new ForbiddenError('User not author nor admin of the survey');
+    }
+
     const survey = await publishSurvey(surveyId);
     res.status(200).json(survey);
   }),
@@ -300,6 +305,11 @@ router.post(
   ]),
   asyncHandler(async (req, res) => {
     const surveyId = Number(req.params.id);
+    const permissionsOk = await userCanEditSurvey(req.user, surveyId);
+    if (!permissionsOk) {
+      throw new ForbiddenError('User not author nor admin of the survey');
+    }
+
     const survey = await unpublishSurvey(surveyId);
     res.status(200).json(survey);
   }),
@@ -315,7 +325,11 @@ router.post(
     param('id').isNumeric().toInt().withMessage('ID must be a number'),
   ]),
   asyncHandler(async (req, res) => {
-    const id = Number(req.params.id);
+    const surveyId = Number(req.params.id);
+    const permissionsOk = await userCanEditSurvey(req.user, id);
+    if (!permissionsOk) {
+      throw new ForbiddenError('User not author nor admin of the survey');
+    }
     const partialPage = req.body as Partial<SurveyPage>;
     const createdSurveyPage = await createSurveyPage(id, partialPage);
     res.status(201).json(createdSurveyPage);
@@ -332,7 +346,12 @@ router.delete(
     param('id').isNumeric().toInt().withMessage('ID must be a number'),
   ]),
   asyncHandler(async (req, res) => {
-    const id = Number(req.params.id);
+    const surveyId = Number(req.params.id);
+    const permissionsOk = await userCanEditSurvey(req.user, surveyId);
+    if (!permissionsOk) {
+      throw new ForbiddenError('User not author nor admin of the survey');
+    }
+
     const deletedSurveyPage = await deleteSurveyPage(id);
     res.status(200).json(deletedSurveyPage);
   }),


### PR DESCRIPTION
Publishing/unpublishing survey and deleting survey page were erroneously allowed for non-authors of the survey, this one should fix it  