### PR TITLE
deep copy data before saving it on clipboard

### DIFF
--- a/client/src/components/admin/EditSurveySideBar.tsx
+++ b/client/src/components/admin/EditSurveySideBar.tsx
@@ -163,12 +163,18 @@ export default function EditSurveySideBar(props: Props) {
                             onClick={(event) => {
                               event.stopPropagation();
                               event.preventDefault();
+                              // Deep copy page to avoid changes to current context
                               const copiedSurveyPage =
                                 replaceTranslationsWithNull(
                                   replaceIdsWithNull({
-                                    ...page,
+                                    ...JSON.parse(JSON.stringify(page)),
                                     id: -1,
-                                    sidebar: { ...page.sidebar, mapLayers: [] },
+                                    sidebar: {
+                                      ...JSON.parse(
+                                        JSON.stringify(page.sidebar),
+                                      ),
+                                      mapLayers: [],
+                                    },
                                   }),
                                 ) as SurveyPage;
 

--- a/client/src/components/admin/EditSurveySideBar.tsx
+++ b/client/src/components/admin/EditSurveySideBar.tsx
@@ -167,12 +167,10 @@ export default function EditSurveySideBar(props: Props) {
                               const copiedSurveyPage =
                                 replaceTranslationsWithNull(
                                   replaceIdsWithNull({
-                                    ...JSON.parse(JSON.stringify(page)),
+                                    ...structuredClone(page),
                                     id: -1,
                                     sidebar: {
-                                      ...JSON.parse(
-                                        JSON.stringify(page.sidebar),
-                                      ),
+                                      ...structuredClone(page.sidebar),
                                       mapLayers: [],
                                     },
                                   }),

--- a/client/src/components/admin/SurveySectionAccordion/SurveySectionAccordion.tsx
+++ b/client/src/components/admin/SurveySectionAccordion/SurveySectionAccordion.tsx
@@ -324,8 +324,11 @@ export default function SurveySectionAccordion(props: Props) {
                 event.preventDefault();
 
                 // Remove all IDs from the section JSON to prevent unwanted references
+                // Create deep copy to avoid unwanted side effects on original
                 const copiedSurveySection = replaceTranslationsWithNull(
-                  replaceIdsWithNull({ ...props.section }),
+                  replaceIdsWithNull({
+                    ...JSON.parse(JSON.stringify(props)).section,
+                  }),
                 );
 
                 // Store section to locale storage for other browser tabs to get access to it

--- a/client/src/components/admin/SurveySectionAccordion/SurveySectionAccordion.tsx
+++ b/client/src/components/admin/SurveySectionAccordion/SurveySectionAccordion.tsx
@@ -327,7 +327,7 @@ export default function SurveySectionAccordion(props: Props) {
                 // Create deep copy to avoid unwanted side effects on original
                 const copiedSurveySection = replaceTranslationsWithNull(
                   replaceIdsWithNull({
-                    ...JSON.parse(JSON.stringify(props)).section,
+                    ...structuredClone(props.section),
                   }),
                 );
 


### PR DESCRIPTION
Removal of translations caused unwanted changes in context and caused changes in UI and if saved, on database.