### PR TITLE
Added polling when getting map layers from RPC

### DIFF
--- a/client/src/components/SurveyStepper.tsx
+++ b/client/src/components/SurveyStepper.tsx
@@ -42,11 +42,11 @@ import ImageSection from './ImageSection';
 import PageConnector from './PageConnector';
 import StepperControls from './StepperControls';
 import SubmissionInfoDialog from './SubmissionInfoDialog';
+import { SurveyFollowUpSections } from './SurveyFollowUpSections';
 import SurveyLanguageMenu from './SurveyLanguageMenu';
 import SurveyMap from './SurveyMap';
 import SurveyQuestion from './SurveyQuestion';
 import TextSection from './TextSection';
-import { SurveyFollowUpSections } from './SurveyFollowUpSections';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -193,6 +193,9 @@ export default function SurveyStepper({
    * Update map's visible layers when page changes
    */
   useEffect(() => {
+    if (currentPage.sidebar.type !== 'map') {
+      return;
+    }
     setVisibleLayers(currentPage.sidebar.mapLayers);
     // If modifying, stop it when changing page
     if (isMapReady) {

--- a/client/src/typings/oskari-rpc.d.ts
+++ b/client/src/typings/oskari-rpc.d.ts
@@ -252,6 +252,22 @@ declare module 'oskari-rpc' {
     msg?: string;
   }
 
+  export interface State {
+    mapfull: {
+      state: {
+        north: number;
+        east: number;
+        selectedLayers: {
+          id: number;
+          opacity: number;
+          style?: string;
+        }[];
+        srs: string;
+        zoom: number;
+      };
+    };
+  }
+
   /**
    * All Oskari events
    */
@@ -306,6 +322,7 @@ declare module 'oskari-rpc' {
     getSupportedFunctions: (callback: (functions: unknown[]) => void) => void;
     getInfo: (callback: (info: any) => void) => void;
     getMapPosition: (callback: (position: any) => void) => void;
+    getCurrentState: (callback: (state: State) => void) => void;
     /**
      * Post an Oskari request
      */


### PR DESCRIPTION
`MapLayerVisibilityRequest`s were sent via RPC too soon when displaying a page with map, because although Oskari responds that it's ready, the layers might not yet be assigned all the way to the internal map state. This is why these visibility requests might fail (race condition).

Replaced `getAllLayers` with a polling function that gets the layers from the map's internal state, to assure that the app may proceed in sending the visibility requests.

There might be better solutions to this in the future, when this issue gets done: https://github.com/oskariorg/oskari-documentation/issues/58

Also (although probably not relevant to the fix) removed the excessive visibility requests when switching to a page without a map.