### PR TITLE
fix: Stop creating attributions element if not defined

### DIFF
--- a/client/src/components/ImageSection.tsx
+++ b/client/src/components/ImageSection.tsx
@@ -61,15 +61,17 @@ export default function ImageSection({ section, isFollowUp = false }: Props) {
           src={`/api/file/${fullFilePath}`}
           alt={section.altText?.[language]}
         />
-        <Typography
-          sx={(theme) => styles(theme).imageCopyright}
-          variant="body2"
-          maxWidth={'100%'}
-          display={'inline-block'}
-          align="right"
-        >
-          {section.attributions?.[surveyLanguage]}
-        </Typography>
+        {section.attributions?.[surveyLanguage] && (
+          <Typography
+            sx={(theme) => styles(theme).imageCopyright}
+            variant="body2"
+            maxWidth={'100%'}
+            display={'inline-block'}
+            align="right"
+          >
+            {section.attributions?.[surveyLanguage]}
+          </Typography>
+        )}
       </Box>
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         <Link href={`/api/file/${fullFilePath}`} target={'__blank'}>

--- a/client/src/components/SurveyStepper.tsx
+++ b/client/src/components/SurveyStepper.tsx
@@ -689,12 +689,14 @@ export default function SurveyStepper({
                   alt={currentPage.sidebar?.imageAltText?.[surveyLanguage]}
                   src={`/api/file/${fullSidebarImagePath}`}
                 />
-                <Typography
-                  sx={(theme) => styles(theme).imageCopyright}
-                  variant="body2"
-                >
-                  {currentPage.sidebar?.imageAttributions?.[surveyLanguage]}
-                </Typography>
+                {currentPage.sidebar?.imageAttributions?.[surveyLanguage] && (
+                  <Typography
+                    sx={(theme) => styles(theme).imageCopyright}
+                    variant="body2"
+                  >
+                    {currentPage.sidebar?.imageAttributions?.[surveyLanguage]}
+                  </Typography>
+                )}
               </>
             )}
           </div>


### PR DESCRIPTION
Stop drawing empty box for empty attributions data on sidepanel / imagesections